### PR TITLE
Add compatibility with Fast DEC

### DIFF
--- a/src/DiagrammaticEquations.jl
+++ b/src/DiagrammaticEquations.jl
@@ -14,7 +14,7 @@ Collage, collate,
 oapply, unique_by, unique_by!, OpenSummationDecapodeOb, OpenSummationDecapode, Open,
 ## acset
 SchDecapode, SchNamedDecapode, AbstractDecapode, AbstractNamedDecapode, NamedDecapode, SummationDecapode,
-contract_operators, add_constant!, add_parameter, fill_names!,  dot_rename!, expand_operators, infer_state_names, recognize_types,
+contract_operators!, contract_operators, add_constant!, add_parameter, fill_names!, dot_rename!, expand_operators, infer_state_names, recognize_types,
 resolve_overloads!, replace_names!,
 apply_inference_rule_op1!, apply_inference_rule_op2!, 
 ## language

--- a/src/DiagrammaticEquations.jl
+++ b/src/DiagrammaticEquations.jl
@@ -20,7 +20,7 @@ apply_inference_rule_op1!, apply_inference_rule_op2!,
 ## language
 @decapode, Term, parse_decapode, term, Eq, DecaExpr,
 # ~~~~~
-Plus, AppCirc1, AppCirc2, Var, Tan, App1, App2, Judgment, 
+Plus, AppCirc1, AppCirc2, Var, Tan, App1, App2, Judgement, 
 ## visualization
 to_graphviz_property_graph, typename,
 ## rewrite

--- a/src/deca/Deca.jl
+++ b/src/deca/Deca.jl
@@ -6,26 +6,12 @@ using Catlab
 
 import ..infer_types!, ..resolve_overloads!
 
-export normalize_unicode, varname, infer_states, infer_types!, resolve_overloads!, typename, spacename, recursive_delete_parents, recursive_delete_parents!, unicode!, op1_res_rules_1D, op2_res_rules_1D, op1_res_rules_2D, op2_res_rules_2D, op1_inf_rules_1D, op2_inf_rules_1D, op1_inf_rules_2D, op2_inf_rules_2D, vec_to_dec!
+export normalize_unicode, varname, infer_types!, resolve_overloads!, typename, spacename, recursive_delete_parents, recursive_delete_parents!, unicode!, op1_res_rules_1D, op2_res_rules_1D, op1_res_rules_2D, op2_res_rules_2D, op1_inf_rules_1D, op2_inf_rules_1D, op1_inf_rules_2D, op2_inf_rules_2D, vec_to_dec!
 
 include("deca_acset.jl")
 include("deca_visualization.jl")
 
-## TODO: where?
-function infer_states(d::SummationDecapode)
-    filter(parts(d, :Var)) do v
-        length(incident(d, v, :tgt)) == 0 &&
-        length(incident(d, v, :res)) == 0 &&
-        length(incident(d, v, :sum)) == 0 &&
-        d[v, :type] != :Literal
-    end
-end
-
-infer_state_names(d) = d[infer_states(d), :name]
-
-
-"""
-    function recursive_delete_parents!(d::SummationDecapode, to_delete::Vector{Int64})
+"""    function recursive_delete_parents!(d::SummationDecapode, to_delete::Vector{Int64})
 
 Delete the given nodes and their parents in the Decapode, recursively.
 """

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -37,15 +37,15 @@ op2_inf_rules_1D = [
   (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, op_names = [:∧, :∧₀₁, :wedge]),
 
   # Rules for L₀, L₁
-  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form0, op_names = [:L, :L₀]),
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, op_names = [:L, :L₁]),    
+  (proj1_type = :Form1, proj2_type = :DualForm0, res_type = :DualForm0, op_names = [:L, :L₀]),
+  (proj1_type = :Form1, proj2_type = :DualForm1, res_type = :DualForm1, op_names = [:L, :L₁]),    
 
   # Rules for i₁
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form0, op_names = [:i, :i₁]),
+  (proj1_type = :Form1, proj2_type = :DualForm1, res_type = :DualForm0, op_names = [:i, :i₁]),
 
   # Rules for divison and multiplication
-  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, op_names = [:./, :.*]),
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, op_names = [:./, :.*]),
+  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
 
   # WARNING: This parameter type inference might be wrong, depending on what the user gives as a parameter
   #= (proj1_type = :Parameter, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
@@ -56,12 +56,18 @@ op2_inf_rules_1D = [
   (proj1_type = :Form1, proj2_type = :Parameter, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Form2, proj2_type = :Parameter, res_type = :Form2, op_names = [:/, :./, :*, :.*]),=#
   
-  (proj1_type = :Literal, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
-  (proj1_type = :Literal, proj2_type = :Form1, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
-  
   (proj1_type = :Form0, proj2_type = :Literal, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Form1, proj2_type = :Literal, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
   
+  (proj1_type = :DualForm0, proj2_type = :Literal, res_type = :DualForm0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :DualForm1, proj2_type = :Literal, res_type = :DualForm1, op_names = [:/, :./, :*, :.*]),
+
+  (proj1_type = :Literal, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Literal, proj2_type = :Form1, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
+
+  (proj1_type = :Literal, proj2_type = :DualForm0, res_type = :DualForm0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Literal, proj2_type = :DualForm1, res_type = :DualForm1, op_names = [:/, :./, :*, :.*]),
+
   (proj1_type = :Constant, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Constant, proj2_type = :Form1, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Form0, proj2_type = :Constant, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
@@ -108,7 +114,10 @@ op1_inf_rules_2D = [
   # Rules for negation
   (src_type = :Form0, tgt_type = :Form0, op_names = [:neg, :(-)]),
   (src_type = :Form1, tgt_type = :Form1, op_names = [:neg, :(-)]),
-  (src_type = :Form2, tgt_type = :Form2, op_names = [:neg, :(-)])]
+  (src_type = :Form2, tgt_type = :Form2, op_names = [:neg, :(-)]),
+  (src_type = :DualForm0, tgt_type = :DualForm0, op_names = [:neg, :(-)]),
+  (src_type = :DualForm1, tgt_type = :DualForm1, op_names = [:neg, :(-)]),
+  (src_type = :DualForm2, tgt_type = :DualForm2, op_names = [:neg, :(-)])]
     
 op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   # Rules for ∧₁₁, ∧₂₀, ∧₀₂
@@ -116,13 +125,11 @@ op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, op_names = [:∧, :∧₂₀, :wedge]),
   (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, op_names = [:∧, :∧₀₂, :wedge]),
 
-  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:L]),    
-
   # Rules for L₂
-  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form2, op_names = [:L, :L₂]),    
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:L, :L₂]),    
 
   # Rules for i₁
-  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form1, op_names = [:i, :i₁]),
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm1, op_names = [:i, :i₂]),
   
   # Rules for subtraction
   (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, op_names = [:-, :.-]),
@@ -133,105 +140,108 @@ op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   (proj1_type = :DualForm2, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:-, :.-]),
 
   # Rules for divison and multiplication
-  (proj1_type = :Form2, proj2_type = :Form2, res_type = :Form2, op_names = [:./, :.*]),
+  (proj1_type = :Form2, proj2_type = :Form2, res_type = :Form2, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Literal, proj2_type = :Form2, res_type = :Form2, op_names = [:/, :./, :*, :.*]),
-  (proj1_type = :Form2, proj2_type = :Literal, res_type = :Form2, op_names = [:/, :./, :*, :.*])])
+  (proj1_type = :Form2, proj2_type = :Literal, res_type = :Form2, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :DualForm2, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Literal, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :DualForm2, proj2_type = :Literal, res_type = :DualForm2, op_names = [:/, :./, :*, :.*])])
+  """
+  These are the default rules used to do function resolution in the 1D exterior calculus.
+  """
+  op1_res_rules_1D = [
+    # Rules for d.
+    (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
+    (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
+    # Rules for ⋆.
+    (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :⋆),
+    (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :⋆),
+    (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
+    (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
+    (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :star),
+    (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :star),
+    (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :star),
+    (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :star),
+    # Rules for δ.
+    (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ),
+    (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :codif),
+     # Rules for Δ
+    (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ)]
   
-# TODO: You could write a method which auto-generates these rules given degree N.
-
-"""
-These are the default rules used to do function resolution in the 1D exterior calculus.
-"""
-op1_res_rules_1D = [
-  # Rules for d.
-  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
-  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
-  # Rules for ⋆.
-  (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :⋆),
-  (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :⋆),
-  (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
-  (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
-  (src_type = :Form0, tgt_type = :DualForm1, resolved_name = :⋆₀, op = :star),
-  (src_type = :Form1, tgt_type = :DualForm0, resolved_name = :⋆₁, op = :star),
-  (src_type = :DualForm1, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :star),
-  (src_type = :DualForm0, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :star),
-  # Rules for δ.
-  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ),
-  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :codif)]
-
-# We merge 1D and 2D rules since it seems op2 rules are metric-free. If
-# this assumption is false, this needs to change.
-op2_res_rules_1D = [
-  # Rules for ∧.
-  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :∧),
-  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :∧),
-  (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, resolved_name = :∧₀₁, op = :∧),
-  (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :wedge),
-  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :wedge),
-  (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, resolved_name = :∧₀₁, op = :wedge),
-  # Rules for L.
-  (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form0, resolved_name = :L₀, op = :L),
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, resolved_name = :L₁, op = :L),
-  # Rules for i.
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form0, resolved_name = :i₁, op = :i)]
-
-
-"""
-These are the default rules used to do function resolution in the 2D exterior calculus.
-"""
-op1_res_rules_2D = [
-  # Rules for d.
-  (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
-  (src_type = :Form1, tgt_type = :Form2, resolved_name = :d₁, op = :d),
-  (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
-  (src_type = :DualForm1, tgt_type = :DualForm2, resolved_name = :dual_d₁, op = :d),
-  # Rules for ⋆.
-  (src_type = :Form0, tgt_type = :DualForm2, resolved_name = :⋆₀, op = :⋆),
-  (src_type = :Form1, tgt_type = :DualForm1, resolved_name = :⋆₁, op = :⋆),
-  (src_type = :Form2, tgt_type = :DualForm0, resolved_name = :⋆₂, op = :⋆),
-  (src_type = :DualForm2, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
-  (src_type = :DualForm1, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
-  (src_type = :DualForm0, tgt_type = :Form2, resolved_name = :⋆₂⁻¹, op = :⋆),
-  (src_type = :Form0, tgt_type = :DualForm2, resolved_name = :⋆₀, op = :star),
-  (src_type = :Form1, tgt_type = :DualForm1, resolved_name = :⋆₁, op = :star),
-  (src_type = :Form2, tgt_type = :DualForm0, resolved_name = :⋆₂, op = :star),
-  (src_type = :DualForm2, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :star),
-  (src_type = :DualForm1, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :star),
-  (src_type = :DualForm0, tgt_type = :Form2, resolved_name = :⋆₂⁻¹, op = :star),
-  # Rules for δ.
-  (src_type = :Form2, tgt_type = :Form1, resolved_name = :δ₂, op = :δ),
-  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ),
-  (src_type = :Form2, tgt_type = :Form1, resolved_name = :δ₂, op = :codif),
-  (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :codif),
-  # Rules for ∇².
-  # TODO: Call this :nabla2 in ASCII?
-  (src_type = :Form0, tgt_type = :Form0, resolved_name = :∇²₀, op = :∇²),
-  (src_type = :Form1, tgt_type = :Form1, resolved_name = :∇²₁, op = :∇²),
-  (src_type = :Form2, tgt_type = :Form2, resolved_name = :∇²₂, op = :∇²),
-  # Rules for Δ.
-  (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
-  (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
-  (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ),
-  (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :lapl),
-  (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :lapl),
-  (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :lapl)]
-
-# We merge 1D and 2D rules directly here since it seems op2 rules
-# are metric-free. If this assumption is false, this needs to change.
-op2_res_rules_2D = vcat(op2_res_rules_1D, [
-  # Rules for ∧.
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :∧),
-  (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :∧),
-  (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :∧),
-  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :wedge),
-  (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :wedge),
-  (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :wedge),
-  # Rules for L.
-  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form2, resolved_name = :L₂, op = :L),
-  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₂ᵈ, op = :L),
-  # Rules for i.
-  (proj1_type = :Form1, proj2_type = :Form2, res_type = :Form1, resolved_name = :i₂, op = :i)])
-
+  # We merge 1D and 2D rules since it seems op2 rules are metric-free. If
+  # this assumption is false, this needs to change.
+  op2_res_rules_1D = [
+    # Rules for ∧.
+    (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :∧),
+    (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :∧),
+    (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, resolved_name = :∧₀₁, op = :∧),
+    (proj1_type = :Form0, proj2_type = :Form0, res_type = :Form0, resolved_name = :∧₀₀, op = :wedge),
+    (proj1_type = :Form1, proj2_type = :Form0, res_type = :Form1, resolved_name = :∧₁₀, op = :wedge),
+    (proj1_type = :Form0, proj2_type = :Form1, res_type = :Form1, resolved_name = :∧₀₁, op = :wedge),
+    # Rules for L.
+    (proj1_type = :Form1, proj2_type = :DualForm0, res_type = :DualForm0, resolved_name = :L₀, op = :L),
+    (proj1_type = :Form1, proj2_type = :DualForm1, res_type = :DualForm1, resolved_name = :L₁, op = :L),
+    # Rules for i.
+    (proj1_type = :Form1, proj2_type = :DualForm1, res_type = :DualForm0, resolved_name = :i₁, op = :i)]
+  
+  
+  """
+  These are the default rules used to do function resolution in the 2D exterior calculus.
+  """
+  op1_res_rules_2D = [
+    # Rules for d.
+    (src_type = :Form0, tgt_type = :Form1, resolved_name = :d₀, op = :d),
+    (src_type = :Form1, tgt_type = :Form2, resolved_name = :d₁, op = :d),
+    (src_type = :DualForm0, tgt_type = :DualForm1, resolved_name = :dual_d₀, op = :d),
+    (src_type = :DualForm1, tgt_type = :DualForm2, resolved_name = :dual_d₁, op = :d),
+    # Rules for ⋆.
+    (src_type = :Form0, tgt_type = :DualForm2, resolved_name = :⋆₀, op = :⋆),
+    (src_type = :Form1, tgt_type = :DualForm1, resolved_name = :⋆₁, op = :⋆),
+    (src_type = :Form2, tgt_type = :DualForm0, resolved_name = :⋆₂, op = :⋆),
+    (src_type = :DualForm2, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :⋆),
+    (src_type = :DualForm1, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :⋆),
+    (src_type = :DualForm0, tgt_type = :Form2, resolved_name = :⋆₂⁻¹, op = :⋆),
+    (src_type = :Form0, tgt_type = :DualForm2, resolved_name = :⋆₀, op = :star),
+    (src_type = :Form1, tgt_type = :DualForm1, resolved_name = :⋆₁, op = :star),
+    (src_type = :Form2, tgt_type = :DualForm0, resolved_name = :⋆₂, op = :star),
+    (src_type = :DualForm2, tgt_type = :Form0, resolved_name = :⋆₀⁻¹, op = :star),
+    (src_type = :DualForm1, tgt_type = :Form1, resolved_name = :⋆₁⁻¹, op = :star),
+    (src_type = :DualForm0, tgt_type = :Form2, resolved_name = :⋆₂⁻¹, op = :star),
+    # Rules for δ.
+    (src_type = :Form2, tgt_type = :Form1, resolved_name = :δ₂, op = :δ),
+    (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :δ),
+    (src_type = :Form2, tgt_type = :Form1, resolved_name = :δ₂, op = :codif),
+    (src_type = :Form1, tgt_type = :Form0, resolved_name = :δ₁, op = :codif),
+    # Rules for ∇².
+    # TODO: Call this :nabla2 in ASCII?
+    (src_type = :Form0, tgt_type = :Form0, resolved_name = :∇²₀, op = :∇²),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :∇²₁, op = :∇²),
+    (src_type = :Form2, tgt_type = :Form2, resolved_name = :∇²₂, op = :∇²),
+    # Rules for Δ.
+    (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :Δ),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :Δ),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :Δ),
+    (src_type = :Form0, tgt_type = :Form0, resolved_name = :Δ₀, op = :lapl),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₁, op = :lapl),
+    (src_type = :Form1, tgt_type = :Form1, resolved_name = :Δ₂, op = :lapl)]
+  
+  # We merge 1D and 2D rules directly here since it seems op2 rules
+  # are metric-free. If this assumption is false, this needs to change.
+  op2_res_rules_2D = vcat(op2_res_rules_1D, [
+    # Rules for ∧.
+    (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :∧),
+    (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :∧),
+    (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :∧),
+    (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form2, resolved_name = :∧₁₁, op = :wedge),
+    (proj1_type = :Form2, proj2_type = :Form0, res_type = :Form2, resolved_name = :∧₂₀, op = :wedge),
+    (proj1_type = :Form0, proj2_type = :Form2, res_type = :Form2, resolved_name = :∧₀₂, op = :wedge),
+    # Rules for L.
+    (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₂, op = :L),
+    # (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₂ᵈ, op = :L),
+    # Rules for i.
+    (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm1, resolved_name = :i₂, op = :i)])
+    
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 infer_types!(d::SummationDecapode) =

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -146,6 +146,7 @@ op2_inf_rules_2D = vcat(op2_inf_rules_1D, [
   (proj1_type = :DualForm2, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :Literal, proj2_type = :DualForm2, res_type = :DualForm2, op_names = [:/, :./, :*, :.*]),
   (proj1_type = :DualForm2, proj2_type = :Literal, res_type = :DualForm2, op_names = [:/, :./, :*, :.*])])
+
   """
   These are the default rules used to do function resolution in the 1D exterior calculus.
   """

--- a/src/language.jl
+++ b/src/language.jl
@@ -1,34 +1,5 @@
-# Definition of the Decapodes DSL AST
-# TODO: do functions and tans need to be parameterized by a space?
-# TODO: Add support for higher order functions.
-#   - This is straightforward from a language perspective but unclear the best
-#   - way to represent this in a Decapode ACSet.
-
 @intertypes "decapodes.it" module decapodes end
 using .decapodes
-
-# @data Term begin
-#   Var(name::Symbol)
-#   Lit(name::Symbol)
-#   # Judgement(var::Var, dim::Symbol, space::Symbol) # Symbol 1: Form0 Symbol 2: X
-#   AppCirc1(fs::Vector{Symbol}, arg::Term)
-#   App1(f::Symbol, arg::Term)
-#   App2(f::Symbol, arg1::Term, arg2::Term)
-#   Plus(args::Vector{Term})
-#   Mult(args::Vector{Term})
-#   Tan(var::Term)
-# end
-
-
-# @data Equation begin
-#   Eq(lhs::Term, rhs::Term)
-# end
-
-# # A struct to store a complete Decapode
-# @as_record struct DecaExpr
-#   context::Vector{Judgement}
-#   equations::Vector{Equation}
-# end
 
 term(s::Symbol) = Var(normalize_unicode(s))
 term(s::Number) = Lit(Symbol(s))
@@ -198,13 +169,10 @@ function eval_eq!(eq::Equation, d::AbstractDecapode, syms::Dict{Symbol, Int}, de
   return d
 end
 
-#""" Takes a DecaExpr (i.e. what should be constructed using the @Decapode macro)
-#and gives a Decapode ACSet which represents equalities as two operations with the
-#same tgt or res map.
-#"""
-# Just to get up and running, I tagged untyped variables with :infer
-# TODO: write a type checking/inference step for this function to 
-# overwrite the :infer tags
+"""    function Decapode(e::DecaExpr)
+
+Takes a DecaExpr and returns a Decapode ACSet.
+"""
 function Decapode(e::DecaExpr)
   d = Decapode{Any, Any}()
   symbol_table = Dict{Symbol, Int}()
@@ -221,6 +189,10 @@ function Decapode(e::DecaExpr)
   return d
 end
 
+"""    function SummationDecapode(e::DecaExpr)
+
+Takes a DecaExpr and returns a SummationDecapode ACSet.
+"""
 function SummationDecapode(e::DecaExpr)
     d = SummationDecapode{Any, Any, Symbol}()
     symbol_table = Dict{Symbol, Int}()
@@ -245,9 +217,9 @@ function SummationDecapode(e::DecaExpr)
 end
 
 
-"""    macro Decapode(e)
+"""    macro decapode(e)
 
-Construct a Decapode.
+Construct a SummationDecapode using the Decapode Domain-Specific Language.
 """
 macro decapode(e)
   :(SummationDecapode(parse_decapode($(Meta.quot(e)))))

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -2,23 +2,25 @@ using Catlab
 using AlgebraicRewriting
 using AlgebraicRewriting: rewrite
 
-#""" function get_valid_op1s(deca_source::SummationDecapode, varID)
-#Searches SummationDecapode, deca_source, at the request varID
-#and returns all op1s which are allowed to be averaged. Returns
-#an array of indices of valid op1 sources.
-#
-#Namely this is meant to exclude ∂ₜ from being included in an average.
-#"""
+"""    function get_valid_op1s(deca_source::SummationDecapode, varID)
+
+Searches SummationDecapode, deca_source, at the request varID
+and returns all op1s which are allowed to be averaged. Returns
+an array of indices of valid op1 sources.
+
+Namely this is meant to exclude ∂ₜ from being included in an average.
+"""
 function get_valid_op1s(deca_source::SummationDecapode, varID)
     # skip_ops = Set([:∂ₜ])
     indices = incident(deca_source, varID, :tgt)
     return filter!(x -> deca_source[x, :op1] != :∂ₜ, indices)
 end
   
-#""" function is_tgt_of_many_ops(d::SummationDecapode, var)
-#Return true if there are two or more distinct operations leading
-#into Var var (not counting ∂ₜ).
-#"""
+"""    function is_tgt_of_many_ops(d::SummationDecapode, var)
+
+Return true if there are two or more distinct operations leading
+into Var var (not counting ∂ₜ).
+"""
 function is_tgt_of_many_ops(d::SummationDecapode, var)
   op1Count = length(get_valid_op1s(d, var))
   op2Count = length(incident(d, var, :res))
@@ -27,20 +29,22 @@ function is_tgt_of_many_ops(d::SummationDecapode, var)
   op1Count + op2Count + sumCount >= 2
 end
   
-#""" function find_tgts_of_many_ops(d::SummationDecapode)
-#Searches SummationDecapode, d, for all Vars which have two or
-#more distinct operations leading into the same variable.
-#"""
+"""    function find_tgts_of_many_ops(d::SummationDecapode)
+
+Searches SummationDecapode, d, for all Vars which have two or
+more distinct operations leading into the same variable.
+"""
 function find_tgts_of_many_ops(d::SummationDecapode)
   filter(var -> is_tgt_of_many_ops(d, var), parts(d, :Var))
 end
   
-#""" function get_preprocess_indices(deca_source::SummationDecapode)
-#Searches SummationDecapode, deca_source, for all Vars which are
-#valid for average rewriting preprocessing. Namely this just includes
-#all op2 and summation operations. Returns two arrays, first is 
-#array of valid Op2 ids, second is array of valid Σ ids.
-#"""
+"""    function get_preprocess_indices(deca_source::SummationDecapode)
+
+Searches SummationDecapode, deca_source, for all Vars which are
+valid for average rewriting preprocessing. Namely this just includes
+all op2 and summation operations. Returns two arrays, first is 
+array of valid Op2 ids, second is array of valid Σ ids.
+"""
 function get_preprocess_indices(deca_source::SummationDecapode)
     targetOp2 = []
     targetSum = []
@@ -55,13 +59,14 @@ function get_preprocess_indices(deca_source::SummationDecapode)
     return targetOp2, targetSum
 end
   
-#""" function preprocess_average_rewrite(deca_source::SummationDecapode)
-#Preprocesses SummationDecapode, deca_source, for easier average 
-#rewriting later on. Specifically, all op2 and summation results are
-#stored in variables called "Temp" and results are then passed off to 
-#their original result along an op1 called "temp". This "temp" operation
-#is equivalent to an identity function.
-#"""
+"""    function preprocess_average_rewrite(deca_source::SummationDecapode)
+
+Preprocesses SummationDecapode, deca_source, for easier average 
+rewriting later on. Specifically, all op2 and summation results are
+stored in variables called "Temp" and results are then passed off to 
+their original result along an op1 called "temp". This "temp" operation
+is equivalent to an identity function.
+"""
 function preprocess_average_rewrite(deca_source::SummationDecapode)
     targetOp2, targetSum = get_preprocess_indices(deca_source)
 
@@ -204,12 +209,13 @@ function preprocess_average_rewrite(deca_source::SummationDecapode)
     rewrite_match(rule, m)
 end
   
-#""" function process_average_rewrite(deca_source::SummationDecapode)
-#Rewrites SummationDecapode, deca_source, by including averages
-#of redundent operations. While this function only searches for op1s
-#to match on, because of preprocessing, this indirectly includes op2 
-#and summations in the final result.
-#"""
+"""    function process_average_rewrite(deca_source::SummationDecapode)
+
+Rewrites SummationDecapode, deca_source, by including averages
+of redundent operations. While this function only searches for op1s
+to match on, because of preprocessing, this indirectly includes op2 
+and summations in the final result.
+"""
 function process_average_rewrite(deca_source::SummationDecapode)
     targetVars = find_tgts_of_many_ops(deca_source)
 
@@ -304,13 +310,14 @@ function average_rewrite(deca_source::SummationDecapode)
     return process_average_rewrite(preprocess_average_rewrite(deca_source))
 end
 
-#""" function find_variable_mapping(deca_source, deca_tgt)
-#Returns array of match on variables between from a Decapode
-#source to a target, also returns if mapping is valid
-#WARNING: This assumes that variable names are unique.
-#If variable names are not unique or do not exist, 
-#corrsponding mapping value is set to 0.
-#"""
+"""    function find_variable_mapping(deca_source, deca_tgt)
+
+Returns array of match on variables between from a Decapode
+source to a target, also returns if mapping is valid
+WARNING: This assumes that variable names are unique.
+If variable names are not unique or do not exist, 
+corrsponding mapping value is set to 0.
+"""
 function find_variable_mapping(deca_source, deca_tgt)
 
     mapping = []

--- a/test/language.jl
+++ b/test/language.jl
@@ -6,8 +6,6 @@ using Catlab.WiringDiagrams
 using Catlab.WiringDiagrams.DirectedWiringDiagrams
 using Catlab.Graphics
 using Catlab.Programs
-using CombinatorialSpaces
-using CombinatorialSpaces.ExteriorCalculus
 using LinearAlgebra
 using MLStyle
 using Base.Iterators
@@ -229,3 +227,994 @@ Deca = quote
   (A, B, C)::Form0
 end
 
+@testset "Term Construction" begin
+  @test term(:(Ċ)) == Var(:Ċ)
+  @test_throws ErrorException term(:(∂ₜ{Form0}))
+  # @test term(Expr(:ϕ)) == Var(:ϕ)
+  @test typeof(term(:(d₀(C)))) == App1
+  @test typeof(term(:(∘(k, d₀)(C)))) == AppCirc1
+  # @test typeof(term(:(∘(k, d₀)(C,Φ)))) == AppCirc2
+  # @test term(:(∘(k, d₀)(C))) == AppCirc1([:k, :d₀], Var(:C)) #(:App1, ((:Circ, :k, :d₀), Var(:C)))
+  # @test term(:(∘(k, d₀{X})(C))) == (:App1, ((:Circ, :k, :(d₀{X})), Var(:C)))
+  @test_throws MethodError term(:(Ċ == ∘(⋆₀⁻¹{X}, dual_d₁{X}, ⋆₁{X})(ϕ)))
+  @test term(:(∂ₜ(C))) == Tan(Var(:C))
+  # @test term(:(∂ₜ{Form0}(C))) == App1(:Tan, Var(:C))
+end
+
+@testset "Recursive Expr" begin
+  Recursion = quote
+    x::Form0{X}
+    y::Form0{X}
+    z::Form0{X}
+
+    ∂ₜ(z) == f1(x) + ∘(g, h)(y)
+    y == F(f2(x), ρ(x,z))
+  end
+
+  recExpr = parse_decapode(Recursion)
+  rdp = SummationDecapode(recExpr)
+
+  @test nparts(rdp, :Var) == 8
+  @test nparts(rdp, :TVar) == 1
+  @test nparts(rdp, :Op1) == 4
+  @test nparts(rdp, :Op2) == 2
+  @test nparts(rdp, :Σ) == 1
+end
+
+@testset "Diffusion Diagram" begin
+  DiffusionExprBody =  quote
+      (C, Ċ)::Form0{X}
+      ϕ::Form1{X}
+  
+      # Fick's first law
+      ϕ ==  ∘(k, d₀)(C)
+      # Diffusion equation
+      Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+      ∂ₜ(C) == Ċ
+  end
+
+  diffExpr = parse_decapode(DiffusionExprBody)
+  ddp = SummationDecapode(diffExpr)
+  to_graphviz(ddp)
+
+  @test nparts(ddp, :Var) == 3
+  @test nparts(ddp, :TVar) == 1
+  @test nparts(ddp, :Op1) == 3
+  @test nparts(ddp, :Op2) == 0
+end
+
+
+@testset "Advection Diagram" begin
+  Advection = quote
+      C::Form0{X}
+      (V, ϕ)::Form1{X}
+
+      ϕ == ∧₀₁(C,V)
+  end
+
+  advdecexpr = parse_decapode(Advection)
+  advdp = SummationDecapode(advdecexpr)
+  @test nparts(advdp, :Var) == 3
+  @test nparts(advdp, :TVar) == 0
+  @test nparts(advdp, :Op1) == 0
+  @test nparts(advdp, :Op2) == 1
+end
+
+@testset "Superposition Diagram" begin
+  Superposition = quote
+      (C, Ċ)::Form0{X}
+      (ϕ, ϕ₁, ϕ₂)::Form1{X}
+
+      ϕ == ϕ₁ + ϕ₂
+      Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+      ∂ₜ(C) == Ċ
+  end
+
+  superexp = parse_decapode(Superposition)
+  supdp = SummationDecapode(superexp)
+  @test nparts(supdp, :Var) == 5
+  @test nparts(supdp, :TVar) == 1
+  @test nparts(supdp, :Op1) == 2
+  @test nparts(supdp, :Op2) == 0
+  @test nparts(supdp, :Σ) == 1
+  @test nparts(supdp, :Summand) == 2
+end
+
+@testset "AdvectionDiffusion Diagram" begin
+  AdvDiff = quote
+      (C, Ċ)::Form0{X}
+      (V, ϕ, ϕ₁, ϕ₂)::Form1{X}
+
+      # Fick's first law
+      ϕ₁ ==  (k ∘ d₀)(C)
+      # Diffusion equation
+      Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+      ϕ₂ == ∧₀₁(C,V)
+
+      ϕ == ϕ₁ + ϕ₂
+      Ċ == ∘(⋆₀⁻¹, dual_d₁, ⋆₁)(ϕ)
+      ∂ₜ(C) == Ċ
+  end
+
+  advdiff = parse_decapode(AdvDiff)
+  advdiffdp = SummationDecapode(advdiff)
+  @test nparts(advdiffdp, :Var) == 6
+  @test nparts(advdiffdp, :TVar) == 1
+  @test nparts(advdiffdp, :Op1) == 4
+  @test nparts(advdiffdp, :Op2) == 1
+  @test nparts(advdiffdp, :Σ) == 1
+  @test nparts(advdiffdp, :Summand) == 2
+end
+
+@testset "Type Inference" begin
+  # Warning, this testing depends on the fact that varname, form information is 
+  # unique within a decapode even though this is not enforced
+  function get_name_type_pair(d::SummationDecapode)
+    Set(zip(d[:name], d[:type]))
+  end
+
+  # The type of the tgt of ∂ₜ is inferred.
+  Test1 = quote
+    C::Form0{X}
+    ∂ₜ(C) == C
+  end
+  t1 = SummationDecapode(parse_decapode(Test1))
+  infer_types!(t1)
+
+  # We use set equality because we do not care about the order of the Var table.
+  names_types_1 = Set(zip(t1[:name], t1[:type]))
+  names_types_expected_1 = Set([(:C, :Form0)])
+  @test issetequal(names_types_1, names_types_expected_1)
+
+  # The type of the src of ∂ₜ is inferred.
+  Test2 = quote
+    C::infer{X}
+    ∂ₜ(C) == C
+  end
+  t2 = SummationDecapode(parse_decapode(Test2))
+  t2[only(incident(t2, :C, :name)), :type] = :Form0
+  infer_types!(t2)
+
+  names_types_2 = Set(zip(t2[:name], t2[:type]))
+  names_types_expected_2 = Set([(:C, :Form0)])
+  @test issetequal(names_types_2, names_types_expected_2)
+
+  # The type of the tgt of d is inferred.
+  Test3 = quote
+    C::Form0{X}
+    D::infer{X}
+    E::infer{X}
+    #C::infer{X}
+    #D::Form1{X}
+    #E::infer{X}
+    D == d(C)
+    E == d(D)
+  end
+  t3 = SummationDecapode(parse_decapode(Test3))
+  #t3_inferred = infer_types!(t3)
+  infer_types!(t3)
+
+  names_types_3 = Set(zip(t3[:name], t3[:type]))
+  names_types_expected_3 = Set([(:C, :Form0), (:D, :Form1), (:E, :Form2)])
+  @test issetequal(names_types_3, names_types_expected_3)
+
+  # The type of the src and tgt of d is inferred.
+  Test4 = quote
+    C::infer{X}
+    D::Form1{X}
+    E::infer{X}
+    D == d(C)
+    E == d(D)
+  end
+  t4 = SummationDecapode(parse_decapode(Test4))
+  #t4_inferred = infer_types!(t4)
+  infer_types!(t4)
+
+  names_types_4 = Set(zip(t4[:name], t4[:type]))
+  names_types_expected_4 = Set([(:C, :Form0), (:D, :Form1), (:E, :Form2)])
+  @test issetequal(names_types_4, names_types_expected_4)
+
+  # The type of the src of d is inferred.
+  Test5 = quote
+    C::infer{X}
+    D::Form1{X}
+    D == d(C)
+  end
+  t5 = SummationDecapode(parse_decapode(Test5))
+  infer_types!(t5)
+
+  names_types_5 = Set(zip(t5[:name], t5[:type]))
+  names_types_expected_5 = Set([(:C, :Form0), (:D, :Form1)])
+  @test issetequal(names_types_5, names_types_expected_5)
+
+  # The type of the src of d is inferred.
+  Test6 = quote
+    A::Form0{X}
+    (B,C,D,E,F)::infer{X}
+    B == d(A)
+    C == d(B)
+    D == ⋆(C)
+    E == d(D)
+    F == d(E)
+  end
+  t6 = SummationDecapode(parse_decapode(Test6))
+  infer_types!(t6)
+
+  names_types_6 = Set(zip(t6[:name], t6[:type]))
+  names_types_expected_6 = Set([
+    (:A, :Form0),     (:B, :Form1),     (:C, :Form2),
+    (:F, :DualForm2), (:E, :DualForm1), (:D, :DualForm0)])
+  @test issetequal(names_types_6, names_types_expected_6)
+
+  # The type of a summand is inferred.
+  Test7 = quote
+    A::Form0{X}
+    (B,C,D,E,F)::infer{X}
+    A == B+C+D+E+F
+  end
+  t7 = SummationDecapode(parse_decapode(Test7))
+  infer_types!(t7)
+
+  types_7 = Set(t7[:type])
+  types_expected_7 = Set([:Form0])
+  @test issetequal(types_7, types_expected_7)
+
+  # The type of a sum is inferred.
+  Test8 = quote
+    B::Form0{X}
+    (A,C,D,E,F)::infer{X}
+    A == B+C+D+E+F
+  end
+  t8 = SummationDecapode(parse_decapode(Test8))
+  infer_types!(t8)
+
+  types_8 = Set(t8[:type])
+  types_expected_8 = Set([:Form0])
+  @test issetequal(types_8, types_expected_8)
+
+  # Type inference of op1 propagates through sums.
+  Test8 = quote
+    Γ::Form0{X}
+    (A,B,C,D,E,F,Θ)::infer{X}
+    B == d(Γ)
+    A == B+C+D+E+F
+    Θ == d(A)
+  end
+  t8 = SummationDecapode(parse_decapode(Test8))
+  infer_types!(t8)
+
+  names_types_8 = Set(zip(t8[:name], t8[:type]))
+  names_types_expected_8 = Set([
+    (:Γ, :Form0),
+    (:A, :Form1), (:B, :Form1), (:C, :Form1), (:D, :Form1), (:E, :Form1), (:F, :Form1),
+    (:Θ, :Form2)])
+  @test issetequal(names_types_8, names_types_expected_8)
+
+  function makeInferPathDeca(log_cycles; infer_path = false)
+    cycles = 2 ^ log_cycles
+    num_nodes = 6 * cycles
+    num_ops = num_nodes - 1
+
+    if(infer_path)
+      type_arr = vcat(:Form0, fill(:infer, num_nodes - 1))
+    else
+      type_arr = repeat([:Form0, :Form1, :Form2, :DualForm0, :DualForm1, :DualForm2], cycles)
+    end
+
+    InferPathTest = @acset SummationDecapode{Any, Any, Symbol} begin
+      Var = num_nodes
+      type = type_arr
+      name = map(x -> Symbol("•$x"), 1:num_nodes)
+
+      Op1 = num_ops
+      src = 1:num_ops
+      tgt = 2:num_ops + 1
+      op1 = repeat([:d, :d, :⋆, :d, :d, :⋆], cycles)[1:num_ops]
+    end
+  end
+  # log_cycles > 6 starts to be slow
+  log_cycles = 3
+
+  decapode_to_infer = makeInferPathDeca(log_cycles, infer_path = true)
+  decapode_expected = makeInferPathDeca(log_cycles)
+  infer_types!(decapode_to_infer)
+  @test decapode_to_infer == decapode_expected
+
+  # Inference can happen "through" composed ops.
+  Test9 = quote
+    A::Form0{X}
+    B::infer{X}
+    B == ∘(d,d,⋆,d,d)(A)
+  end
+  t9 = SummationDecapode(parse_decapode(Test9))
+  t9 = expand_operators(t9)
+  infer_types!(t9)
+
+  names_types_9 = Set(zip(t9[:name], t9[:type]))
+  names_types_expected_9 = Set([
+    (:A, :Form0),     (Symbol("•_1_", 1), :Form1),     (Symbol("•_1_", 2), :Form2),
+    (:B, :DualForm2), (Symbol("•_1_", 4), :DualForm1), (Symbol("•_1_", 3), :DualForm0)])
+  @test issetequal(names_types_9, names_types_expected_9)
+
+  # Basic op2 inference using ∧
+  Test10 = quote
+    (A, B)::Form0{X}
+    C::infer{X}
+
+    D::Form0{X}
+    E::Form1{X}
+    (F, H)::infer{X}
+
+    C == ∧(A, B)
+
+    F == ∧(D, E)
+    H == ∧(E, D)
+  end
+  t10 = SummationDecapode(parse_decapode(Test10))
+  infer_types!(t10)
+
+  names_types_10 = get_name_type_pair(t10)
+  names_types_expected_10 = Set([(:F, :Form1), (:B, :Form0), (:C, :Form0), (:H, :Form1), (:A, :Form0), (:E, :Form1), (:D, :Form0)])
+  @test issetequal(names_types_10, names_types_expected_10)
+
+  # Basic op2 inference using L
+  Test11 = quote
+    A::Form1{X}
+    E::DualForm1{X}
+    B::DualForm0{X}
+    (C, D)::infer{X}
+
+    C == L(A, B)
+    D == L(A, E)
+  end
+  t11 = SummationDecapode(parse_decapode(Test11))
+  infer_types!(t11)
+
+  names_types_11 = get_name_type_pair(t11)
+  names_types_expected_11 = Set([(:A, :Form1), (:B, :DualForm0), (:C, :DualForm0), (:E, :DualForm1), (:D, :DualForm1)])
+  @test issetequal(names_types_11, names_types_expected_11)
+
+  # Basic op2 inference using i
+  Test12 = quote
+    A::Form1{X}
+    B::DualForm1{X}
+    C::infer{X}
+
+    C == i(A, B)
+  end
+  t12 = SummationDecapode(parse_decapode(Test12))
+  infer_types!(t12)
+
+  names_types_12 = get_name_type_pair(t12)
+  names_types_expected_12 = Set([(:A, :Form1), (:B, :DualForm1), (:C, :DualForm0)])
+  @test issetequal(names_types_12, names_types_expected_12)
+
+  #2D op2 inference using ∧
+  Test13 = quote
+    (A, B)::Form1{X}
+    C::infer{X}
+
+    D::Form0{X}
+    E::Form2{X}
+    (F, H)::infer{X}
+
+    C == ∧(A, B)
+
+    F == ∧(D, E)
+    H == ∧(E, D)
+  end
+  t13 = SummationDecapode(parse_decapode(Test13))
+  infer_types!(t13)
+
+  names_types_13 = get_name_type_pair(t13)
+  names_types_expected_13 = Set([(:E, :Form2), (:B, :Form1), (:C, :Form2), (:A, :Form1), (:F, :Form2), (:H, :Form2), (:D, :Form0)])
+  @test issetequal(names_types_13, names_types_expected_13)
+
+  # 2D op2 inference using L
+  Test14 = quote
+    A::Form1{X}
+    B::DualForm2{X}
+    C::infer{X}
+
+    C == L(A, B)
+  end
+  t14 = SummationDecapode(parse_decapode(Test14))
+  infer_types!(t14)
+
+  names_types_14 = get_name_type_pair(t14)
+  names_types_expected_14 = Set([(:C, :DualForm2), (:A, :Form1), (:B, :DualForm2)])
+  @test issetequal(names_types_14, names_types_expected_14)
+
+  # 2D op2 inference using i
+  Test15 = quote
+    A::Form1{X}
+    B::DualForm2{X}
+    C::infer{X}
+
+    C == i(A, B)
+  end
+  t15 = SummationDecapode(parse_decapode(Test15))
+  infer_types!(t15)
+
+  names_types_15 = get_name_type_pair(t15)
+  names_types_expected_15 = Set([(:A, :Form1), (:B, :DualForm2), (:C, :DualForm1)])
+  @test issetequal(names_types_15, names_types_expected_15)
+
+  # Special case of a summation with a mix of infer and Literal.
+  t16 = @decapode begin
+    A == 2 + C + D
+  end
+  infer_types!(t16)
+
+  names_types_16 = get_name_type_pair(t16)
+  names_types_expected_16 = Set([(:A, :Constant), (:C, :Constant), (:D, :Constant), (Symbol("2"), :Literal)])
+  @test issetequal(names_types_16, names_types_expected_16)
+
+  # Special case of a summation with a mix of Form, Constant, and infer.
+  t17 = @decapode begin
+    A::Form0
+    C::Constant
+    A == C + D
+  end
+  infer_types!(t17)
+
+  names_types_17 = get_name_type_pair(t17)
+  names_types_expected_17 = Set([(:A, :Form0), (:C, :Constant), (:D, :Form0)])
+  @test issetequal(names_types_17, names_types_expected_17)
+
+  # Special case of a summation with a mix of infer and Constant.
+  t18 = @decapode begin
+    C::Constant
+    A == C + D
+  end
+  infer_types!(t18)
+
+  names_types_18 = get_name_type_pair(t18)
+  names_types_expected_18 = Set([(:A, :Constant), (:C, :Constant), (:D, :Constant)])
+  @test issetequal(names_types_18, names_types_expected_18)
+end
+
+@testset "Overloading Resolution" begin
+  # d overloading is resolved.
+  Test1 = quote
+    A::Form0{X}
+    B::Form1{X}
+    C::Form2{X}
+    D::DualForm0{X}
+    E::DualForm1{X}
+    F::DualForm2{X}
+    B == d(A)
+    C == d(B)
+    E == d(D)
+    F == d(E)
+  end
+  t1 = SummationDecapode(parse_decapode(Test1))
+  resolve_overloads!(t1)
+
+  op1s_1 = t1[:op1]
+  op1s_expected_1 = [:d₀ , :d₁, :dual_d₀, :dual_d₁]
+  @test op1s_1 == op1s_expected_1
+
+  # ⋆ overloading is resolved.
+  Test2 = quote
+    C::Form0{X}
+    D::DualForm2{X}
+    E::Form1{X}
+    F::DualForm1{X}
+    G::Form2{X}
+    H::DualForm0{X}
+    D == ⋆(C)
+    C == ⋆(D)
+    E == ⋆(F)
+    F == ⋆(E)
+    G == ⋆(H)
+    H == ⋆(G)
+  end
+  t2 = SummationDecapode(parse_decapode(Test2))
+  resolve_overloads!(t2)
+
+  op1s_2 = t2[:op1]
+  # Note: The Op1 table of the decapode created does not have the functions
+  # listed in the order in which they appear in Test2.
+  op1s_expected_2 = [:⋆₀ , :⋆₀⁻¹ , :⋆₁⁻¹ , :⋆₁ , :⋆₂⁻¹ , :⋆₂]
+  @test op1s_2 == op1s_expected_2
+
+  # All overloading on the de Rahm complex is resolved.
+  Test3 = quote
+    A::Form0{X}
+    B::Form1{X}
+    C::Form2{X}
+    D::DualForm0{X}
+    E::DualForm1{X}
+    F::DualForm2{X}
+    B == d(A)
+    C == d(B)
+    E == d(D)
+    F == d(E)
+    F == ⋆(A)
+    A == ⋆(F)
+    E == ⋆(B)
+    B == ⋆(E)
+    D == ⋆(C)
+    C == ⋆(D)
+  end
+  t3 = SummationDecapode(parse_decapode(Test3))
+  resolve_overloads!(t3)
+
+  op1s_3 = t3[:op1]
+  # Note: The Op1 table of the decapode created does not have the functions
+  # listed in the order in which they appear in Test2.
+  op1s_expected_3 = [:d₀ , :d₁, :dual_d₀, :dual_d₁, :⋆₀ , :⋆₀⁻¹ , :⋆₁ , :⋆₁⁻¹ , :⋆₂ , :⋆₂⁻¹]
+  @test op1s_3 == op1s_expected_3
+
+  Test4 = quote
+    (A, C)::Form0{X}
+    (B, D, E)::Form1{X}
+
+    (I,H,F)::DualForm0{X}
+    (J,G)::DualForm1{X}
+
+    C == ∧(A, A)
+    D == ∧(A, B)
+    E == ∧(B, A)
+    F == L(B, I)
+    G == L(B, J)
+    H == i(B, J)
+  end
+  t4 = SummationDecapode(parse_decapode(Test4))
+  resolve_overloads!(t4)
+  op2s_4 = t4[:op2]
+  op2s_expected_4 = [:∧₀₀ , :∧₀₁, :∧₁₀, :L₀, :L₁, :i₁]
+  @test op2s_4 == op2s_expected_4
+
+  Test5 = quote
+    A::Form0{X}
+    B::Form1{X}
+    (C, D, E, F)::Form2{X}
+
+    (I, G)::DualForm2{X}
+    H::DualForm1{X}
+
+    D == ∧(B, B)
+    E == ∧(A, C)
+    F == ∧(C, A)
+    G == L(B, I)
+    H == i(B, I)
+  end
+  t5 = SummationDecapode(parse_decapode(Test5))
+  resolve_overloads!(t5)
+  op2s_5 = t5[:op2]
+  op2s_expected_5 = [:∧₁₁, :∧₀₂, :∧₂₀, :L₂, :i₂]
+  @test op2s_5 == op2s_expected_5
+end
+
+@testset "Type Inference and Overloading Resolution Integration" begin
+  # Momentum-formulation of Navier Stokes on sphere
+  DiffusionExprBody = quote
+    (T, Ṫ)::Form0{X}
+    ϕ::DualForm1{X}
+    k::Parameter{X}
+    # Fick's first law
+    ϕ ==  ⋆(k*d(T))
+    # Diffusion equation
+    Ṫ ==  ⋆(d(ϕ))
+  end
+  Diffusion = SummationDecapode(parse_decapode(DiffusionExprBody))
+  AdvectionExprBody = quote
+    (M,V)::Form1{X}  #  M = ρV
+    (ρ, p, T, Ṫ)::Form0{X}
+    V == M/avg(ρ)
+    ρ == p / R₀(T)
+    Ṫ == neg(⋆(L(V, ⋆(T))))
+  end
+  Advection = SummationDecapode(parse_decapode(AdvectionExprBody))
+  SuperpositionExprBody = quote
+    (T, Ṫ, Ṫ₁, Ṫₐ)::Form0{X}
+    Ṫ == Ṫ₁ + Ṫₐ
+    ∂ₜ(T) == Ṫ 
+  end
+  Superposition = SummationDecapode(parse_decapode(SuperpositionExprBody))
+  compose_continuity = @relation () begin
+    diffusion(T, Ṫ₁)
+    advection(M, ρ, P, T, Ṫₐ)
+    superposition(T, Ṫ, Ṫ₁, Ṫₐ)
+  end
+  continuity_cospan = oapply(compose_continuity,
+                  [Open(Diffusion, [:T, :Ṫ]),
+                  Open(Advection, [:M, :ρ, :p, :T, :Ṫ]),
+                  Open(Superposition, [:T, :Ṫ, :Ṫ₁, :Ṫₐ])])
+
+  continuity = apex(continuity_cospan)
+  NavierStokesExprBody = quote
+    (M, Ṁ, G, V)::Form1{X}
+    (T, ρ, p, ṗ)::Form0{X}
+    (two,three,kᵥ)::Parameter{X}
+    V == M/avg(ρ)
+    Ṁ == neg(L(V, ⋆(V)))*avg(ρ) + 
+          kᵥ*(Δ(V) + d(δ(V))/three) +
+          d(i(V, ⋆(V))/two)*avg(ρ) +
+          neg(d(p)) +
+          G*avg(ρ)
+    ∂ₜ(M) == Ṁ
+    ṗ == neg(⋆(L(V, ⋆(p)))) # *Lie(3Form) = Div(*3Form x v) --> conservation of pressure
+    ∂ₜ(p) == ṗ
+  end
+  NavierStokes = SummationDecapode(parse_decapode(NavierStokesExprBody))
+  compose_heatXfer = @relation () begin
+    continuity(M, ρ, P, T)
+    navierstokes(M, ρ, P, T)
+  end
+  heatXfer_cospan = oapply(compose_heatXfer,
+                  [Open(continuity, [:M, :ρ, :P, :T]),
+                  Open(NavierStokes, [:M, :ρ, :p, :T])])
+  HeatXfer = apex(heatXfer_cospan)
+
+  bespoke_op1_inf_rules = [
+  # Rules for avg.
+  (src_type = :Form0, tgt_type = :Form1, op_names = [:avg]),
+  # Rules for R₀.
+  (src_type = :Form0, tgt_type = :Form0, op_names = [:R₀])]
+
+  #= bespoke_op2_inf_rules = [
+  (proj1_type = :Parameter, proj2_type = :Form0, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Parameter, proj2_type = :Form1, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Parameter, proj2_type = :Form2, res_type = :Form2, op_names = [:/, :./, :*, :.*]),
+
+  (proj1_type = :Form0, proj2_type = :Parameter, res_type = :Form0, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Form1, proj2_type = :Parameter, res_type = :Form1, op_names = [:/, :./, :*, :.*]),
+  (proj1_type = :Form2, proj2_type = :Parameter, res_type = :Form2, op_names = [:/, :./, :*, :.*])] =#
+
+  infer_types!(HeatXfer, vcat(bespoke_op1_inf_rules, op1_inf_rules_2D),
+    op2_inf_rules_2D)
+
+  names_types_hx = zip(HeatXfer[:name], HeatXfer[:type])
+
+  names_types_expected_hx = [
+    (:T, :Form0), (:continuity_Ṫ₁, :Form0), (:continuity_diffusion_ϕ, :DualForm1), (:continuity_diffusion_k, :Parameter), (Symbol("continuity_diffusion_•1"), :DualForm2), (Symbol("continuity_diffusion_•2"), :Form1), (Symbol("continuity_diffusion_•3"), :Form1), (:M, :Form1), (:continuity_advection_V, :Form1), (:ρ, :Form0), (:P, :Form0), (:continuity_Ṫₐ, :Form0), (Symbol("continuity_advection_•1"), :Form0), (Symbol("continuity_advection_•2"), :Form1), (Symbol("continuity_advection_•3"), :DualForm2), (Symbol("continuity_advection_•4"), :Form0), (Symbol("continuity_advection_•5"), :DualForm2), (:continuity_Ṫ, :Form0), (:navierstokes_Ṁ, :Form1), (:navierstokes_G, :Form1), (:navierstokes_V, :Form1), (:navierstokes_ṗ, :Form0), (:navierstokes_two, :Parameter), (:navierstokes_three, :Parameter), (:navierstokes_kᵥ, :Parameter), (Symbol("navierstokes_•1"), :DualForm2), (Symbol("navierstokes_•2"), :Form1), (Symbol("navierstokes_•3"), :Form1), (Symbol("navierstokes_•4"), :DualForm1), (Symbol("navierstokes_•5"), :DualForm1), (Symbol("navierstokes_•6"), :DualForm1), (Symbol("navierstokes_•7"), :Form1), (Symbol("navierstokes_•8"), :Form1), (Symbol("navierstokes_•9"), :Form1), (Symbol("navierstokes_•10"), :Form1), (Symbol("navierstokes_•11"), :Form1), (:navierstokes_sum_1, :Form1), (Symbol("navierstokes_•12"), :Form0), (Symbol("navierstokes_•13"), :Form1), (Symbol("navierstokes_•14"), :Form1), (Symbol("navierstokes_•15"), :Form0), (Symbol("navierstokes_•16"), :DualForm0), (Symbol("navierstokes_•17"), :DualForm1), (Symbol("navierstokes_•18"), :Form1), (Symbol("navierstokes_•19"), :Form1), (Symbol("navierstokes_•20"), :Form1), (:navierstokes_sum_2, :Form0), (Symbol("navierstokes_•21"), :Form1), (Symbol("navierstokes_•22"), :Form1), (Symbol("navierstokes_•23"), :DualForm2)]
+
+  @test issetequal(names_types_hx, names_types_expected_hx)
+
+  bespoke_op2_res_rules = [
+  # Rules for L.
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :Form2, resolved_name = :L₀, op = :L),
+  (proj1_type = :Form1, proj2_type = :DualForm2, res_type = :DualForm2, resolved_name = :L₀, op = :L),
+  (proj1_type = :Form1, proj2_type = :Form1, res_type = :Form1, resolved_name = :L₁′, op = :L)]
+
+  resolve_overloads!(HeatXfer, op1_res_rules_2D,
+    vcat(bespoke_op2_res_rules, op2_res_rules_2D))
+
+  op1s_hx = HeatXfer[:op1]
+  op1s_expected_hx = [:d₀, :⋆₁, :dual_d₁, :⋆₀⁻¹, :avg, :R₀, :⋆₀, :⋆₀⁻¹, :neg, :∂ₜ, :avg, :⋆₁, :neg, :avg, :Δ₁, :δ₁, :d₀, :⋆₁, :d₀, :avg, :d₀, :neg, :avg, :∂ₜ, :⋆₀, :⋆₀⁻¹, :neg, :∂ₜ]
+  @test op1s_hx == op1s_expected_hx
+  op2s_hx = HeatXfer[:op2]
+  op2s_expected_hx = [:*, :/, :/, :L₀, :/, :L₁, :*, :/, :*, :i₁, :/, :*, :*, :L₀]
+  @test op2s_hx == op2s_expected_hx
+end
+
+@testset "Compilation Transformation" begin
+
+  # contract_operators does not change the order of op1s.
+  Test1 = quote
+    (A,B)::Form0{X}
+    B == ∘(j,i,h,g,f)(A)
+  end
+  t1_orig = SummationDecapode(parse_decapode(Test1))
+  t1_expanded = expand_operators(t1_orig)
+  t1_contracted = contract_operators(t1_expanded)
+  @test t1_orig == t1_contracted
+  # contract_operators does not mutate its argument.
+  @test t1_contracted !== t1_expanded
+
+  # contract_operators works on multiple chains.
+  Test2 = quote
+    (A,B,C,D)::Form0{X}
+    B == ∘(d,d,⋆,d,d)(A)
+    D == ∘(d,d,⋆,d,d)(C)
+  end
+  t2_orig = SummationDecapode(parse_decapode(Test2))
+  t2_expanded = expand_operators(t2_orig)
+  t2_contracted = contract_operators(t2_expanded)
+  #@test t2_orig == t2_contracted
+  @test issetequal(
+                  [(t2_orig[:src][i], t2_orig[:tgt][i], t2_orig[:op1][i]) for i in parts(t2_orig, :Op1)],
+                  [(t2_contracted[:src][i], t2_contracted[:tgt][i], t2_contracted[:op1][i]) for i in parts(t2_contracted, :Op1)])
+
+
+  # contract_operators "absorbs ∘s".
+  t3_orig = SummationDecapode(parse_decapode(quote
+    (A,B)::Form0{X}
+    B == f(∘(g)(A))
+    #D == ∘(g)(f(C)) # Uncomment when parsing supports this
+  end))
+  t3_expanded = expand_operators(t3_orig)
+  t3_contracted = contract_operators(t3_expanded)
+  @test t3_contracted == SummationDecapode(parse_decapode(quote
+    (A,B)::Form0{X}
+    B == ∘(g,f)(A)
+  end))
+
+  # contract_operators does not contract through when a var is
+  # the target of multiple ops.
+  t4_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D)::Form0{X}
+    C == f(A)
+    C == g(B)
+    D == h(C)
+  end))
+  @test t4_orig == contract_operators(t4_orig)
+
+  # contract_operators does not contract through when a var is a summand.
+  t5_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D,E)::Form0{X}
+    B == f(A)
+    C == g(B)
+    E == B + D
+  end))
+  @test t5_orig == contract_operators(t5_orig)
+
+  # recursive_delete_parents does not change an empty Decapode.
+  t6_orig = SummationDecapode(parse_decapode(quote
+
+  end))
+  t6_rec_del = recursive_delete_parents(t6_orig, Vector{Int64}())
+  @test t6_orig == SummationDecapode{Any, Any, Symbol}()
+  # recursive_delete_parents does not mutate its argument.
+  @test t6_orig !== t6_rec_del
+
+  # recursive_delete_parents deletes a chain of single-child parents.
+  t7_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C)::Form0{X}
+    B == f(A)
+    C == g(B)
+  end))
+  t7_rec_del = recursive_delete_parents(t7_orig, incident(t7_orig, :C, :name))
+  @test t7_rec_del == SummationDecapode{Any, Any, Symbol}()
+
+  # recursive_delete_parents deletes a chain of single-child parents until a
+  # multi-child parent is found.
+  t8_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D,E)::Form0{X}
+    B == f(A)
+    C == g(B)
+    D == h(C)
+
+    E == i(B)
+  end))
+  t8_rec_del = recursive_delete_parents(t8_orig, incident(t8_orig, :D, :name))
+  @test t8_rec_del == SummationDecapode(parse_decapode(quote
+    (A, B, E)::Form0{X}
+    B == f(A)
+
+    E == i(B)
+  end))
+
+  # recursive_delete_parents deletes a multi-child parent if all its children are
+  # deleted.
+  t9_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D,E)::Form0{X}
+    B == f(A)
+    C == g(B)
+
+    D == i(A)
+    E == j(D)
+  end))
+  t9_rec_del = recursive_delete_parents(t9_orig,
+                                reduce(vcat, incident(t9_orig, [:C, :E], :name)))
+  @test t9_rec_del == SummationDecapode{Any, Any, Symbol}()
+
+  # recursive_delete_parents deletes π₁ and π₂ of an Op2 with missing result.
+  t10_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D)::Form0{X}
+    C == f(A,B)
+    D == g(C)
+  end))
+  t10_rec_del = recursive_delete_parents(t10_orig, incident(t10_orig, :D, :name))
+  @test t10_rec_del == SummationDecapode{Any, Any, Symbol}()
+
+  # recursive_delete_parents only deletes an π₁ or π₂ of an Op2 if it is not used in
+  # another Op2.
+  t11_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D,E)::Form0{X}
+    D == f(A,B)
+    E == g(B,C)
+  end))
+  t11_rec_del = recursive_delete_parents(t11_orig, incident(t11_orig, :D, :name))
+  # We should test if Decapodes are isomorphic, but Catlab
+  # doesn't do this yet.
+  #@test t11_rec_del == SummationDecapode(parse_decapode(quote
+  #  (B,C,E)::Form0{X}
+  #  E == g(B,C)
+  #end))
+  @test t11_rec_del == @acset SummationDecapode{Any, Any, Symbol} begin
+    Var  = 3
+    Op2  = 1
+
+    type = [:Form0, :Form0, :Form0]
+    name = [:E, :B, :C]
+
+    proj1 = [2]
+    proj2 = [3]
+    res   = [1]
+    op2   = [:g]
+  end
+
+  # If π₁ and π₂ of an Op2 point to the same Var, that Var is used in some
+  # other computation, but this Op2 has deleted result, then delete the Op2,
+  # but not the Var.
+  t12_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D)::Form0{X}
+    C == f(A,A)
+    D == g(A,B)
+  end))
+  t12_rec_del = recursive_delete_parents(t12_orig, incident(t12_orig, :C, :name))
+  @test t12_rec_del == SummationDecapode(parse_decapode(quote
+    (A,B,D)::Form0{X}
+    D == g(A,B)
+  end))
+
+  # recursive_delete_parents does not delete a Var if it is used in a summation.
+  t13_orig = SummationDecapode(parse_decapode(quote
+    (A,B,C,D,E)::Form0{X}
+    D == A + B + C
+
+    E == f(A)
+  end))
+  t13_rec_del = recursive_delete_parents(t13_orig, incident(t13_orig, :E, :name))
+  @test t13_rec_del == SummationDecapode(parse_decapode(quote
+    (A,B,C,D)::Form0{X}
+    D == A + B + C
+  end))
+
+  # Test recursive_delete_parents on a real physics.
+  Veronis = SummationDecapode(parse_decapode(quote
+    B::DualForm0{X}
+    E::Form1{X}
+    σ::Form1{X}
+    J::Form1{X}
+    (negone,c,ε₀)::Constant{X}
+
+    ∂ₜ(E) == ((negone * (J - σ .* E))./ε₀) + ((c * c).*(⋆₁⁻¹(d₀(B))))
+
+    ∂ₜ(B) == ⋆₂(d₁(E))
+  end))
+  Veronis_rec_del = recursive_delete_parents(Veronis, incident(Veronis, :Ḃ, :name))
+  @test Veronis_rec_del == SummationDecapode(parse_decapode(quote
+    B::DualForm0{X}
+    E::Form1{X}
+    σ::Form1{X}
+    J::Form1{X}
+    (negone,c,ε₀)::Constant{X}
+
+    ∂ₜ(E) == ((negone * (J - σ .* E))./ε₀) + ((c * c).*(⋆₁⁻¹(d₀(B))))
+  end))
+
+  # Test recursive_delete_parents on a real physics.
+  Veronis = SummationDecapode(parse_decapode(quote
+    B::DualForm0{X}
+    E::Form1{X}
+    σ::Form1{X}
+    J::Form1{X}
+    (negone,c,ε₀)::Constant{X}
+
+    ∂ₜ(E) == ((negone * (J - σ .* E))./ε₀) + ((c * c).*(⋆₁⁻¹(d₀(B))))
+
+    ∂ₜ(B) == ⋆₂(d₁(E))
+  end))
+  Veronis_rec_del = recursive_delete_parents(Veronis, incident(Veronis, :Ė, :name))
+  # We should test if Decapodes are isomorphic, but Catlab
+  # doesn't do this yet.
+  #@test Veronis_rec_del == SummationDecapode(parse_decapode(quote
+  #  B::DualForm0{X}
+  #  E::Form1{X}
+
+  #  ∂ₜ(B) == ⋆₂(d₁(E))
+  #end))
+  @test Veronis_rec_del ==  @acset SummationDecapode{Any, Any, Symbol} begin
+    Var  = 4
+    TVar = 1
+    Op1  = 3
+
+    type = [:DualForm0, :Form1, :infer, :infer]
+    name = [:B, :E, :sum_1, :Ḃ]
+    
+    incl = [4]
+
+    src = [3, 1, 2]
+    tgt = [4, 4, 3]
+
+    op1 = [:⋆₂, :∂ₜ, :d₁]
+  end
+end
+
+@testset "ASCII & Vector Calculus Operators" begin
+# Test ASCII to Unicode conversion on an Op2.
+t1 = @decapode begin
+  A == wedge(C, D)
+end
+unicode!(t1)
+
+op2s_1 = Set(t1[:op2])
+op2s_expected_1 = Set([:∧])
+@test issetequal(op2s_1, op2s_expected_1)
+
+# Test ASCII to Unicode conversion with multiple occurences of the same operator.
+t2 = @decapode begin
+  A == wedge(C, D)
+  B == wedge(E, F)
+end
+unicode!(t2)
+
+op2s_2 = Set(t2[:op2])
+op2s_expected_2 = Set([:∧])
+@test issetequal(op2s_2, op2s_expected_2)
+
+# Test ASCII to Unicode conversion works with composed operators after expansion.
+t3 = @decapode begin
+  A == ∘(star, lapl, star_inv)(B)
+end
+t3 = expand_operators(t3)
+unicode!(t3)
+
+op1s_3 = Set(t3[:op1])
+op1s_expected_3 = Set([:⋆,:Δ,:⋆⁻¹])
+@test issetequal(op1s_3, op1s_expected_3)
+
+# Test ASCII tangent operator identifies a TVar.
+t4 = @decapode begin
+  A == dt(B)
+end
+@test nparts(t4, :TVar) == 1
+
+# Test vec_to_dec! on a single operator.
+t5 = @decapode begin
+  A == div(B)
+end
+vec_to_dec!(t5)
+
+op1s_5 = Set(t5[:op1])
+op1s_expected_5 = Set([[:⋆,:d,:⋆]])
+@test issetequal(op1s_5, op1s_expected_5)
+
+# Test divergence of gradient is the Laplacian.
+t6 = @decapode begin
+  A == ∘(grad, div)(B)
+end
+t6 = expand_operators(t6)
+vec_to_dec!(t6)
+t6 = contract_operators(t6)
+@test only(t6[:op1]) == [:d,:⋆,:d,:⋆]
+
+# Test curl of curl is a vector Laplacian.
+t7 = @decapode begin
+  A == ∘(∇x, ∇x)(B)
+end
+t7 = expand_operators(t7)
+vec_to_dec!(t7)
+t7 = contract_operators(t7)
+@test only(t7[:op1]) == [:d,:⋆,:d,:⋆]
+
+# Test advection is divergence of wedge product.
+t8 = @decapode begin
+  A == adv(B, C)
+end
+vec_to_dec!(t8)
+
+@test only(t8[:op1]) == [:⋆,:d,:⋆]
+@test only(t8[:op2]) == :∧
+
+# Test multiple advections.
+t9 = @decapode begin
+  A == adv(B, C)
+  D == adv(E, F)
+end
+vec_to_dec!(t9)
+
+t9_expected = @decapode begin
+  A == ∘(⋆,d,⋆)(B ∧ C)
+  D == ∘(⋆,d,⋆)(E ∧ F)
+end
+t9_expected[incident(t9_expected, Symbol("•1"), :name), :name] = Symbol("•_adv_1")
+t9_expected[incident(t9_expected, Symbol("•2"), :name), :name] = Symbol("•_adv_2")
+@test is_isomorphic(t9, t9_expected)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 
-#= include("pretty.jl")
+include("pretty.jl")
 
 @testset "Core" begin
   include("core.jl")
@@ -8,7 +8,7 @@ end
 
 @testset "Composition" begin
   include("composition.jl")
-end =#
+end
 
 @testset "Language" begin
   include("language.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Test
 
-include("pretty.jl")
+#= include("pretty.jl")
 
 @testset "Core" begin
   include("core.jl")
@@ -8,7 +8,7 @@ end
 
 @testset "Composition" begin
   include("composition.jl")
-end
+end =#
 
 @testset "Language" begin
   include("language.jl")

--- a/test/visualization.jl
+++ b/test/visualization.jl
@@ -72,3 +72,64 @@ Test3 = SummationDecapode(parse_decapode(quote
 
 t3 = to_graphviz(Test3)
 @test Graphviz.filter_statements(t3, Graphviz.Node, :label) == ["A:Ω₀", "B:Ω₁", "C:Ω₂", "D:Ω̃₀", "E:Ω̃₁", "F:Ω̃₂", "G:ΩL", "H:ΩP", "I:ΩC", "J:Ω•", "", ""]
+
+# Same decapode as Test2 but with all names the same
+Test3 = @acset SummationDecapode{Any, Any, Symbol}  begin
+  Var = 7
+  type = Any[:Form0, :Form0, :Form0, :Form0, :infer, :infer, :infer]
+  name = [:A, :A, :A, :A, :A, :A, :A]
+
+  TVar = 1
+  incl = [5]
+
+  Op1 = 1
+  src = [4]
+  tgt = [5]
+  op1 = Any[:∂ₜ]
+
+  Op2 = 2
+  proj1 = [1, 3]
+  proj2 = [2, 2]
+  res = [6, 7]
+  op2 = Any[:k, :p]
+
+  Σ = 1
+  sum = [5]
+
+  Summand = 2
+  summand = [6, 7]
+  summation = [1, 1]
+end
+
+t3 = to_graphviz(Test3, verbose = true)
+@test Graphviz.filter_statements(t3, Graphviz.Edge, :label) == ["∂ₜ", "π₁", "π₂", "k", "π₁", "π₂", "p", "+"]
+@test Graphviz.filter_statements(t3, Graphviz.Node, :label) == ["A:Ω₀", "A:Ω₀", "A:Ω₀", "A:Ω₀", "A:Ω•", "A:Ω•", "A:Ω•", "", "", "Ω₀×Ω₀", "Ω₀×Ω₀", "Σ1"]
+@test Graphviz.filter_statements(t3, Graphviz.Node, :shape) == ["none", "none", "rectangle", "rectangle", "circle"]
+
+Test4 = @acset SummationDecapode{Any, Any, Symbol} begin
+  Var = 5
+  type = [:Form0, :Form0, :Form0, :Form0, :Form0]
+  name = [Symbol("_A"), :A, Symbol("_•"), Symbol("•_"), Symbol("_")]
+end
+
+t4 = to_graphviz(Test4, directed = false, verbose = false)
+@test Graphviz.filter_statements(t4, Graphviz.Node, :label) == ["A:Ω₀", "A:Ω₀", "•:Ω₀", ":Ω₀", ":Ω₀"]
+
+t5 = to_graphviz(Test4, directed = false, verbose = true)
+@test Graphviz.filter_statements(t5, Graphviz.Node, :label) == ["_A:Ω₀", "A:Ω₀", "_•:Ω₀", "•_:Ω₀", "_:Ω₀"]
+
+Test6 = SummationDecapode(parse_decapode(quote
+           A::Form0
+           B::Form1
+           C::Form2
+           D::DualForm0
+           E::DualForm1
+           F::DualForm2
+           G::Literal
+           H::Parameter
+           I::Constant
+           J::infer
+           end))
+
+t6 = to_graphviz(Test6)
+@test Graphviz.filter_statements(t6, Graphviz.Node, :label) == ["A:Ω₀", "B:Ω₁", "C:Ω₂", "D:Ω̃₀", "E:Ω̃₁", "F:Ω̃₂", "G:ΩL", "H:ΩP", "I:ΩC", "J:Ω•", "", ""]


### PR DESCRIPTION
This PR is part of a coordinated release between DiagrammaticEquations, Decapodes, and CombinatorialSpaces, of various updates enabling speedier versions of DEC operators. A few bug and `Warning` fixes are included, as are many tests which were removed as part of the Decapodes-DiagrammaticEquations repo split.

This PR is to be merged simultaneously with the major PR in CombinatorialSpaces and a supporting PR in Decapodes, after testing that 3 local copies of these libraries, all `dev`'d together, are compatible.

This PR is ready to merge upon the above condition.