### PR TITLE
Add ACSets@0.3 to compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-ACSets = "0.2"
+ACSets = "0.2, 0.3"
 AlgebraicRewriting = "0.2, 0.3"
 Catlab = "0.15, 0.16"
 DataStructures = "0.18.13"


### PR DESCRIPTION
Originally posted by @lukem12345 in https://github.com/AlgebraicJulia/DiagrammaticEquations.jl/pull/14/commits/d25683c8fcf09f274690196b33d9dadff8b0195a.

I don't know anything about whether DiagrammaticEquations is actually compatible with ACSets 0.3, but I want to make sure that change doesn't slip through the cracks.