### PR TITLE
Check black list when contracting operators

### DIFF
--- a/src/acset.jl
+++ b/src/acset.jl
@@ -353,7 +353,7 @@ function find_chains(d::SummationDecapode;
     [incident(d, Vector{Int64}(filter(i -> !isnothing(i), infer_states(d))), :src),
      incident(d, d[:res], :src),
      incident(d, d[:sum], :src),
-     d[rvrv(incident(d, collect(black_list), :op1)), :tgt]
+     d[collect(Iterators.flatten(incident(d, collect(black_list), :op1))), :tgt]
     ]))
 
 

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -351,8 +351,7 @@ function find_chains(d::SummationDecapode;
     [incident(d, Vector{Int64}(filter(i -> !isnothing(i), infer_states(d))), :src),
      incident(d, d[:res], :src),
      incident(d, d[:sum], :src),
-     d[collect(Iterators.flatten(incident(d, collect(black_list), :op1))), :tgt]
-    ]))
+     incident(d, d[collect(Iterators.flatten(incident(d, collect(black_list), :op1))), :tgt], :src)]))
 
   passes_white_list(x) = isempty(white_list) ? true : x ∈ white_list
   passes_black_list(x) = x ∉ black_list

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -285,11 +285,13 @@ function expand_operators(d::SummationDecapode)
   return e
 end
 
-"""    function contract_operators(d::SummationDecapode; allowable_ops::Set{Symbol} = Set{Symbol}())
+"""    function contract_operators(d::SummationDecapode; white_list::Set{Symbol} = Set{Symbol}(), black_list::Set{Symbol} = Set{Symbol}())
 
 Find chains of Op1s in the given Decapode, and replace them with
 a single Op1 with a vector of function names. After this process,
-all Vars that are not a part of any computation are removed.
+all Vars that are not a part of any computation are removed. If a
+white list is provided, only chain those operators. If a black list
+is provided, do not chain those operators.
 """
 function contract_operators(d::SummationDecapode;
   white_list::Set{Symbol} = Set{Symbol}(),
@@ -331,16 +333,12 @@ function remove_neighborless_vars!(d::SummationDecapode)
   d
 end
 
-"""
-    function find_chains(d::SummationDecapode;
-      white_list::Set{Symbol} = Set{Symbol}(),
-      black_list::Set{Symbol} = Set{Symbol}())
+"""    function find_chains(d::SummationDecapode; white_list::Set{Symbol} = Set{Symbol}(), black_list::Set{Symbol} = Set{Symbol}())
 
 Find chains of Op1s in the given Decapode. A chain ends when the
 target of the last Op1 is part of an Op2 or sum, or is a target
-of multiple Op1s. Only operators with names included in the
-allowable_ops set are allowed to be contracted. If the set is
-empty then all operators are allowed.
+of multiple Op1s. If a white list is provided, only chain those
+operators. If a black list is provided, do not chain those operators.
 """
 function find_chains(d::SummationDecapode;
     white_list::Set{Symbol} = Set{Symbol}(),
@@ -355,7 +353,6 @@ function find_chains(d::SummationDecapode;
      incident(d, d[:sum], :src),
      d[collect(Iterators.flatten(incident(d, collect(black_list), :op1))), :tgt]
     ]))
-
 
   passes_white_list(x) = isempty(white_list) ? true : x ∈ white_list
   passes_black_list(x) = x ∉ black_list
@@ -399,6 +396,7 @@ function find_chains(d::SummationDecapode;
   end
   return chains
 end
+
 function add_constant!(d::AbstractNamedDecapode, k::Symbol)
     return add_part!(d, :Var, type=:Constant, name=k)
 end

--- a/test/language.jl
+++ b/test/language.jl
@@ -1283,6 +1283,21 @@ end
 
     op1 = [:⋆₂, :∂ₜ, :d₁]
   end
+
+  t14_orig = @decapode begin
+    C == a(b(c(d(e(f(g(D)))))))
+  end
+  t14_contracted = contract_operators(t14_orig,
+    black_list=Set([:d]))
+  @test issetequal(t14_contracted[:op1], [:d, [:g, :f, :e], [:c, :b, :a]])
+
+  t15_orig = @decapode begin
+    C == a(b(c(d(e(f(g(D)))))))
+  end
+  t15_contracted = contract_operators(t15_orig,
+    white_list=Set([:a, :b, :c]),
+    black_list=Set([:d]))
+  @test issetequal(t15_contracted[:op1], [:g, :f, :e, :d, [:c, :b, :a]])
 end
 
 @testset "ASCII & Vector Calculus Operators" begin


### PR DESCRIPTION
The `contract_operators` function finds chains of unary operators, and replaces them with a single operator containing a vector of the operators from that chain.

We currently support the ability to only contract when operators are in some given white list of operators. When there is no white list given, we default to allowing any operator to be chained.

It will simplify future Decapode manipulation if we also support a black list of operators. If an operator is in the black list, such an operator will not be chained.