### PR TITLE
Revert Rewriting to 0.3.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 ACSets = "0.2"
-AlgebraicRewriting = "0.2, 0.3"
+AlgebraicRewriting = "0.2 - 0.3.2"
 Catlab = "0.15, 0.16"
 DataStructures = "0.18.13"
 MLStyle = "0.4.17"


### PR DESCRIPTION
This is a quick fix to get rewriting tests working again. We should update the rewriting code however to use the latest version, at this time 0.3.3.