### PR TITLE
Average redundant computations manually

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.1.3"
 
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
-AlgebraicRewriting = "725a01d3-f174-5bbd-84e1-b9417bad95d9"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
@@ -14,7 +13,6 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 ACSets = "0.2"
-AlgebraicRewriting = "0.2 - 0.3.2"
 Catlab = "0.15, 0.16"
 DataStructures = "0.18.13"
 MLStyle = "0.4.17"

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -70,7 +70,8 @@ function average_rewrite!(d::SummationDecapode)
     Sigma = add_part!(d, :Σ, sum=summed_inters)
     inters = reduce(vcat, [int_op1s, int_op2s, int_sums])
     add_parts!(d, :Summand, summand=inters, summation=fill(Sigma,length(inters)), length(inters))
-    add_part!(d, :Op1, src=summed_inters, tgt=v, op1=Symbol("avg$(id_num-1)"))
+    lit = add_part!(d, :Var, name=Symbol(string(id_num-1)), type=:Literal)
+    add_part!(d, :Op2, proj1=summed_inters, proj2=lit, res=v, op2=Symbol("/"))
   end
   d
 end

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -1,6 +1,4 @@
 using Catlab
-using AlgebraicRewriting
-using AlgebraicRewriting: rewrite
 
 """    function get_valid_op1s(deca_source::SummationDecapode, varID)
 
@@ -11,9 +9,8 @@ an array of indices of valid op1 sources.
 Namely this is meant to exclude ∂ₜ from being included in an average.
 """
 function get_valid_op1s(deca_source::SummationDecapode, varID)
-    # skip_ops = Set([:∂ₜ])
     indices = incident(deca_source, varID, :tgt)
-    return filter!(x -> deca_source[x, :op1] != :∂ₜ, indices)
+    filter!(x -> deca_source[x, :op1] ∉ [:∂ₜ,:dt], indices)
 end
   
 """    function is_tgt_of_many_ops(d::SummationDecapode, var)
@@ -34,310 +31,58 @@ end
 Searches SummationDecapode, d, for all Vars which have two or
 more distinct operations leading into the same variable.
 """
-function find_tgts_of_many_ops(d::SummationDecapode)
+find_tgts_of_many_ops(d::SummationDecapode) =
   filter(var -> is_tgt_of_many_ops(d, var), parts(d, :Var))
+
+function average_rewrite!(d::SummationDecapode)
+  function add_var_and_inc(id_num,v)
+    inter = add_part!(d, :Var,
+      name=Symbol("oc$(id_num)_"*string(d[v,:name])),
+      type=d[v,:type])
+    inter, id_num+1
+  end
+  while !isempty(find_tgts_of_many_ops(d))
+    id_num = 0
+    v = first(find_tgts_of_many_ops(d))
+    # 1. Add a new intermediate Var for each operation.
+    int_op1s = map(get_valid_op1s(d, v)) do op1
+      inter, id_num = add_var_and_inc(id_num,v)
+      add_part!(d, :Op1, src=d[op1, :src], tgt=inter, op1=d[op1, :op1])
+      inter
+    end
+    int_op2s = map(incident(d, v, :res)) do op2
+      inter, id_num = add_var_and_inc(id_num,v)
+      add_part!(d, :Op2, proj1=d[op2, :proj1], proj2=d[op2, :proj2], res=inter, op2=d[op2, :op2])
+      inter
+    end
+    int_sums = map(incident(d, v, :sum)) do sum
+      inter, id_num = add_var_and_inc(id_num,v)
+      Sigma = add_part!(d, :Σ, sum=inter)
+      d[incident(d, sum, :summation), :summation] = Sigma
+      inter
+    end
+    # 2. Remove the old operations pointing into this Var.
+    rem_parts!(d, :Op1, get_valid_op1s(d, v))
+    rem_parts!(d, :Op2, incident(d, v, :res))
+    rem_parts!(d, :Σ, incident(d, v, :sum))
+    # 3. Compute this Var by taking the average of the intermediates.
+    summed_inters, id_num = add_var_and_inc(id_num,v)
+    Sigma = add_part!(d, :Σ, sum=summed_inters)
+    inters = reduce(vcat, [int_op1s, int_op2s, int_sums])
+    add_parts!(d, :Summand, summand=inters, summation=fill(Sigma,length(inters)), length(inters))
+    add_part!(d, :Op1, src=summed_inters, tgt=v, op1=Symbol("avg$(id_num-1)"))
+  end
+  d
 end
-  
-"""    function get_preprocess_indices(deca_source::SummationDecapode)
 
-Searches SummationDecapode, deca_source, for all Vars which are
-valid for average rewriting preprocessing. Namely this just includes
-all op2 and summation operations. Returns two arrays, first is 
-array of valid Op2 ids, second is array of valid Σ ids.
-"""
-function get_preprocess_indices(deca_source::SummationDecapode)
-    targetOp2 = []
-    targetSum = []
-
-    targetVars = find_tgts_of_many_ops(deca_source)
-
-    for var in targetVars
-        append!(targetOp2, incident(deca_source, var, :res))
-        append!(targetSum, incident(deca_source, var, :sum))
-    end
-
-    return targetOp2, targetSum
-end
-  
-"""    function preprocess_average_rewrite(deca_source::SummationDecapode)
-
-Preprocesses SummationDecapode, deca_source, for easier average 
-rewriting later on. Specifically, all op2 and summation results are
-stored in variables called "Temp" and results are then passed off to 
-their original result along an op1 called "temp". This "temp" operation
-is equivalent to an identity function.
-"""
-function preprocess_average_rewrite(deca_source::SummationDecapode)
-    targetOp2, targetSum = get_preprocess_indices(deca_source)
-
-    # If we don't need to preprocess then don't
-    if(length(targetOp2) == 0 && length(targetSum) == 0)
-        return deca_source
-    end
-
-    LHS = []
-    RHS = []
-
-    SuperMatch = []
-    SuperVarMap = Vector{Int}()
-    SuperOp2Map = Vector{Int}()
-    SuperSigmaMap = Vector{Int}()
-    SuperSummandMap = Vector{Int}()
-
-    serial = 0
-    # Process all of the target rewrites for op2
-    for opID in targetOp2
-
-        vars = [deca_source[opID, :proj1], deca_source[opID, :proj2], deca_source[opID, :res]]
-        types = deca_source[vars, :type]
-        names = deca_source[vars, :name]
-        op2name = deca_source[opID, :op2]
-
-        Match = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = 3
-            type = types
-            name = names
-
-            Op2 = 1
-            proj1 = [1]
-            proj2 = [2]
-            res = [3]
-            op2 = op2name
-        end
-
-        I = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = 3
-            type = types
-            name = names
-        end
-
-        Sub = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = 4
-            type = vcat(types, types[end])
-            name = vcat(names, Symbol("Temp_", serial))
-
-            Op1 = 1
-            src = [4]
-            tgt = [3]
-            op1 = [:temp]
-
-            Op2 = 1
-            proj1 = [1]
-            proj2 = [2]
-            res = [4]
-            op2 = op2name
-        end
-
-        serial += 1
-
-        L = ACSetTransformation(I, Match, Var = 1:3)
-        R = ACSetTransformation(I, Sub, Var = 1:3)
-
-        push!(LHS, L)
-        push!(RHS, R)
-        push!(SuperMatch, Match)
-
-        append!(SuperVarMap, vars)
-        push!(SuperOp2Map, opID)
-    end
-    
-    # Process all of the target rewrites for sums
-    for sumID in targetSum
-        summandIDs = incident(deca_source, sumID, :summation)
-        vars = vcat(deca_source[summandIDs, :summand], deca_source[sumID, :sum])
-        types = deca_source[vars, :type]
-        names = deca_source[vars, :name]
-        
-        rewrite_size = length(vars)
-        nary = rewrite_size - 1
-
-        Match = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = rewrite_size
-            type = types
-            name = names
-
-            Σ = 1
-            sum = [rewrite_size]
-
-            Summand = nary
-            summand = 1:nary
-            summation = fill(1, nary)
-        end
-
-        I = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = rewrite_size
-            type = types
-            name = names
-        end
-
-        Sub = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = rewrite_size + 1
-            type = vcat(types, types[end])
-            name = vcat(names, Symbol("Temp_", serial))
-
-            Op1 = 1
-            src = [rewrite_size + 1]
-            tgt = [rewrite_size]
-            op1 = [:temp]
-
-            Σ = 1
-            sum = [rewrite_size + 1]
-
-            Summand = nary
-            summand = 1:nary
-            summation = fill(1, nary)
-        end
-
-        serial += 1
-
-        L = ACSetTransformation(I, Match, Var = 1:rewrite_size)
-        R = ACSetTransformation(I, Sub, Var = 1:rewrite_size)
-
-        push!(LHS, L)
-        push!(RHS, R)
-        push!(SuperMatch, Match)
-
-        append!(SuperVarMap, vars)
-        push!(SuperSigmaMap, sumID)
-        append!(SuperSummandMap, summandIDs)
-    end
-
-    # Combine all rules in parallel and apply
-    rule = Rule(oplus(LHS), oplus(RHS))
-    m = ACSetTransformation(oplus(SuperMatch), deca_source, Var = SuperVarMap, Op2 = SuperOp2Map, Σ = SuperSigmaMap, Summand = SuperSummandMap)
-
-    rewrite_match(rule, m)
-end
-  
-"""    function process_average_rewrite(deca_source::SummationDecapode)
-
-Rewrites SummationDecapode, deca_source, by including averages
-of redundent operations. While this function only searches for op1s
-to match on, because of preprocessing, this indirectly includes op2 
-and summations in the final result.
-"""
-function process_average_rewrite(deca_source::SummationDecapode)
-    targetVars = find_tgts_of_many_ops(deca_source)
-
-    # If no rewrites available, then don't rewrite
-    if(length(targetVars) == 0)
-        return deca_source
-    end
-
-    LHS = []
-    RHS = []
-
-    SuperMatch = []
-    SuperVarMap = Vector{Int}()
-    SuperOp1Map = Vector{Int}()
-
-    varSerial = 0
-    sumSerial = 0
-
-    # Create rewrite rules for multiple op1s leading into target
-    for varID in targetVars
-        targetOp1 = get_valid_op1s(deca_source, varID)
-        vars = vcat(deca_source[targetOp1, :src], varID)
-
-        num_nodes_match = length(vars)
-        nary_of_rewrite = num_nodes_match - 1
-
-        result_index = num_nodes_match
-        sum_index = 2 * result_index
-
-        variable_types = deca_source[vars, :type]
-        variable_var =  deca_source[vars, :name]
-        variable_op1 = deca_source[targetOp1, :op1]
-
-        Match = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = num_nodes_match
-            type = variable_types
-            name = variable_var
-
-            Op1 = nary_of_rewrite
-            src = 1:nary_of_rewrite
-            tgt = fill(result_index, nary_of_rewrite)
-            op1 = variable_op1
-        end
-
-        I = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = num_nodes_match
-            type = variable_types
-            name = variable_var
-        end 
-
-        Sub = @acset SummationDecapode{Any, Any, Symbol} begin 
-            Var = 2 * num_nodes_match
-            type = vcat(variable_types, variable_types)
-            name = vcat(variable_var, map(x -> Symbol("••", varSerial + x), 1:nary_of_rewrite), [Symbol("••sum", sumSerial)])
-            Op1 = nary_of_rewrite + 1
-            src = vcat(1:nary_of_rewrite, sum_index)
-            tgt = vcat(num_nodes_match+1:sum_index-1, [result_index])
-            op1 = vcat(variable_op1, Symbol(:avg, nary_of_rewrite))
-            Σ = 1
-            sum = [sum_index]
-            Summand = nary_of_rewrite
-            summand = num_nodes_match+1:sum_index-1
-            summation = fill(1, nary_of_rewrite)
-        end
-
-        varSerial += nary_of_rewrite
-        sumSerial += 1
-
-        L = ACSetTransformation(I, Match, Var = 1:num_nodes_match);
-        R = ACSetTransformation(I, Sub, Var = 1:num_nodes_match);
-        
-        push!(LHS, L)
-        push!(RHS, R)
-        push!(SuperMatch, Match)
-
-        append!(SuperVarMap, vars)
-        append!(SuperOp1Map, targetOp1)
-    end
-
-    # Combine all rewrite rules and apply at once
-    rule = Rule(oplus(LHS), oplus(RHS))
-
-    m = ACSetTransformation(oplus(SuperMatch), deca_source, Var = SuperVarMap, Op1 = SuperOp1Map)
-    rewrite_match(rule, m)
-end
-  
-"""    function average_rewrite(deca_source::SummationDecapode)
-
+"""    function average_rewrite(d::SummationDecapode)
+ 
 Compute each quantitity in the given Decapode by the average of all computation paths leading to that node.
 """
-function average_rewrite(deca_source::SummationDecapode)
-    return process_average_rewrite(preprocess_average_rewrite(deca_source))
+function average_rewrite(d::SummationDecapode)
+  e = SummationDecapode{Any, Any, Symbol}()
+  copy_parts!(e, d, (:Var, :TVar, :Op1, :Op2, :Σ, :Summand))
+  average_rewrite!(e)
+  e
 end
 
-"""    function find_variable_mapping(deca_source, deca_tgt)
-
-Returns array of match on variables between from a Decapode
-source to a target, also returns if mapping is valid
-WARNING: This assumes that variable names are unique.
-If variable names are not unique or do not exist, 
-corrsponding mapping value is set to 0.
-"""
-function find_variable_mapping(deca_source, deca_tgt)
-
-    mapping = []
-    valid_matching = true
-  
-    for varID in parts(deca_source, :Var)
-      varName = deca_source[varID, :name]
-      matches = incident(deca_tgt, varName, :name)
-      if(length(matches) >= 2)
-        # println("Name for variable at index $varID named $varName is not unique. Setting to 0.")
-        valid_matching = false
-        push!(mapping, 0)
-      elseif(length(matches) == 0)
-        # println("Variable at index $varID named $varName does not exist in target. Setting to 0.")
-        valid_matching = false
-        push!(mapping, 0)
-      else
-        push!(mapping, only(matches))
-      end
-    end
-  
-    return mapping, valid_matching
-end

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -54,14 +54,20 @@ Test1 = SummationDecapode(parse_decapode(DecaTest1))
 Test1Res = average_rewrite(Test1)
 
 Test1Expected = @acset SummationDecapode{Any, Any, Symbol} begin
-  Var = 6
-  type = [:Form0, :Form1, :Form2, :Form2, :Form2, :Form2]
-  name = [:D₁, :D₂, :F, :oc0_F, :oc1_F, :oc2_F]
+  Var = 7
+  type = [:Form0, :Form1, :Form2, :Form2, :Form2, :Form2, :Literal]
+  name = [:D₁, :D₂, :F, :oc0_F, :oc1_F, :oc2_F, Symbol("2")]
 
-  Op1 = 3
-  src = [1, 2, 6]
-  tgt = [4, 5, 3]
-  op1 = [:c₁, :c₂, :avg2]
+  Op1 = 2
+  src = [1, 2]
+  tgt = [4, 5]
+  op1 = [:c₁, :c₂]
+
+  Op2 = 1
+  proj1 = [6]
+  proj2 = [7]
+  res = [3]
+  op2 = [:/]
 
   Σ = 1
   sum = [6]
@@ -92,22 +98,28 @@ Test2 = SummationDecapode(parse_decapode(DecaTest2))
 Test2Res = average_rewrite(Test2)
 
 Test2Expected = @acset SummationDecapode{Any, Any, Symbol} begin
-  Var = 11
+  Var = 13
 
-  type = [:Form0, :Form0, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1]
+  type = [:Form0, :Form0, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal]
 
-  name = [:C₁, :C₂, :D₁, :D₂, :F, :oc0_D₁, :oc1_D₁, :oc2_D₁, :oc0_F, :oc1_F, :oc2_F]
+  name = [:C₁, :C₂, :D₁, :D₂, :F, :oc0_D₁, :oc1_D₁, :oc2_D₁, Symbol("2"), :oc0_F, :oc1_F, :oc2_F, Symbol("2")]
 
-  Op1 = 6
-  src = [1, 2, 3, 4, 8, 11]
-  tgt = [6, 7, 9, 10, 3, 5]
-  op1 = [:d₀, :d₀, :c₁, :c₂, :avg2, :avg2]
+  Op1 = 4
+  src = [1, 2, 3, 4]
+  tgt = [6, 7, 10, 11]
+  op1 = [:d₀, :d₀, :c₁, :c₂]
+
+  Op2 = 2
+  proj1 = [8, 12]
+  proj2 = [9, 13]
+  res = [3, 5]
+  op2 = [:/, :/]
 
   Σ = 2
-  sum = [8, 11]
+  sum = [8, 12]
 
   Summand = 4
-  summand = [6, 7, 9, 10]
+  summand = [6, 7, 10, 11]
   summation = [1, 1, 2, 2]
 end
 
@@ -133,22 +145,22 @@ Test3 = SummationDecapode(parse_decapode(DecaTest3))
 Test3Res = average_rewrite(Test3)
 
 Test3Expected = @acset SummationDecapode{Any, Any, Symbol} begin
-  Var = 12
+  Var = 13
 
-  type = [:Form0, :Form0, :Form0, :Form0, :Form1, :Form2, :Form2,  :Form2,  :Form2,  :Form2,  :Form2,  :Form2]
+  type = [:Form0, :Form0, :Form0, :Form0, :Form1, :Form2, :Form2,  :Form2,  :Form2,  :Form2,  :Form2,  :Form2, :Literal]
 
-  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G]
+  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G, Symbol("4")]
 
-  Op1 = 3
-  src = [3, 4, 12]
-  tgt = [8, 9, 7]
-  op1 = [:k, :t, :avg4]
+  Op1 = 2
+  src = [3, 4]
+  tgt = [8, 9]
+  op1 = [:k, :t]
 
-  Op2 = 1
-  proj1 = [1]
-  proj2 = [2]
-  res = [10]
-  op2 = [:∧]
+  Op2 = 2
+  proj1 = [1, 12]
+  proj2 = [2, 13]
+  res = [10, 7]
+  op2 = [:∧, :/]
 
   Σ = 2
   sum = [11, 12]
@@ -174,14 +186,20 @@ Test4 = SummationDecapode(parse_decapode(DecaTest4))
 Test4Res = average_rewrite(Test4)
 
 Test4Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 6
-  type = [:Form0, :Form1, :Form1, :Form1, :Form1, :Form1] 
-  name = [:C, :D, :oc0_D, :oc1_D, :oc2_D, :oc3_D]
+  Var = 7
+  type = [:Form0, :Form1, :Form1, :Form1, :Form1, :Form1, :Literal]
+  name = [:C, :D, :oc0_D, :oc1_D, :oc2_D, :oc3_D, Symbol("3")]
 
-  Op1 = 4
-  src = [1, 1, 1, 6]
-  tgt = [3, 4, 5, 2]
-  op1 = Any[:k, :t, :p, :avg3]
+  Op1 = 3
+  src = [1, 1, 1]
+  tgt = [3, 4, 5]
+  op1 = [:k, :t, :p]
+
+  Op2 = 1
+  proj1 = [6]
+  proj2 = [7]
+  res = [2]
+  op2 = [:/]
 
   Σ = 1
   sum = [6]
@@ -215,15 +233,21 @@ Test5 = SummationDecapode(parse_decapode(DecaTest5))
 Test5Res = average_rewrite(Test5)
 
 Test5Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 14
+  Var = 15
   type = [:Form0, :Form0, :Form1, :Form2, :Form1, :Form0, 
-  :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2]
-  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G, :oc5_G, :oc6_G]
+          :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Literal]
+  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G, :oc5_G, :oc6_G, Symbol("6")]
 
-  Op1 = 7
-  src = [6, 5, 4, 3, 2, 1, 14]
-  tgt = [8, 9, 10, 11, 12, 13, 7]
-  op1 = [:f, :e, :d, :c, :b, :a, :avg6]
+  Op1 = 6
+  src = [6, 5, 4, 3, 2, 1]
+  tgt = [8, 9, 10, 11, 12, 13]
+  op1 = [:f, :e, :d, :c, :b, :a]
+
+  Op2 = 1
+  proj1 = [14]
+  proj2 = [15]
+  res = [7]
+  op2 = [:/]
 
   Σ = 1
   sum = [14]
@@ -254,27 +278,27 @@ Test6 = SummationDecapode(parse_decapode(DecaTest6))
 Test6Res = average_rewrite(Test6)
 
 Test6Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 12
+  Var = 14
   type = [:Form0, :Form1, :Form2, :Form0, :Form1, :Form2, 
-  :Form1, :Form1, :Form1, :Form2, :Form2, :Form2]
-  name = [:A, :B, :C, :D, :E, :F, :oc0_E, :oc1_E, :oc2_E, :oc0_F, :oc1_F, :oc2_F]
+  :Form1, :Form1, :Form1, :Literal, :Form2, :Form2, :Form2, :Literal]
+  name = [:A, :B, :C, :D, :E, :F, :oc0_E, :oc1_E, :oc2_E, Symbol("2"), :oc0_F, :oc1_F, :oc2_F, Symbol("2")]
 
-  Op1 = 4
-  src = [1, 5, 9, 12]
-  tgt = [10, 11, 5, 6]
-  op1 = [:k, :t, :avg2, :avg2]
+  Op1 = 2
+  src = [1, 5]
+  tgt = [11, 12]
+  op1 = [:k, :t]
 
-  Op2 = 2
-  proj1 = [2, 2]
-  proj2 = [3, 4]
-  res = [7, 8]
-  op2 = [:p, :q]
+  Op2 = 4
+  proj1 = [2, 2, 9, 13]
+  proj2 = [3, 4, 10, 14]
+  res = [7, 8, 5, 6]
+  op2 = [:p, :q, :/, :/]
 
   Σ = 2
-  sum = [9, 12]
+  sum = [9, 13]
 
   Summand = 4
-  summand = [7, 8, 10, 11]
+  summand = [7, 8, 11, 12]
   summation = [1, 1, 2, 2]
 end
 
@@ -297,14 +321,15 @@ Test7 = SummationDecapode(parse_decapode(DecaTest7))
 Test7Res = average_rewrite(Test7)
 
 Test7Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 9
-  type = [:Form0, :Form1, :Form2, :Form1, :Form0, :Form2, :Form2, :Form2, :Form2]
-  name = [:A, :B, :C, :D, :E, :F, :oc0_F, :oc1_F, :oc2_F]
+  Var = 10
+  type = [:Form0, :Form1, :Form2, :Form1, :Form0, :Form2, :Form2, :Form2, :Form2, :Literal]
+  name = [:A, :B, :C, :D, :E, :F, :oc0_F, :oc1_F, :oc2_F, Symbol("2")]
 
-  Op1 = 1
-  src = [9]
-  tgt = [6]
-  op1 = [:avg2]
+  Op2 = 1
+  proj1 = [9]
+  proj2 = [10]
+  res = [6]
+  op2 = [:/]
 
   Σ = 3
   sum = [7, 8, 9]
@@ -383,17 +408,23 @@ Test10 = SummationDecapode(parse_decapode(DecaTest10))
 Test10Res = average_rewrite(Test10)
 
 Test10Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 9
-  type = [:Form0, :Form0, :Form0, :Form0, :Form2, :Form2, :Form0, :Form0, :Form0]
-  name = [:A, :B, :C, :D, :Ḣ, :H, :oc0_A, :oc1_A, :oc2_A]
+  Var = 10
+  type = [:Form0, :Form0, :Form0, :Form0, :Form2, :Form2, :Form0, :Form0, :Form0, :Literal]
+  name = [:A, :B, :C, :D, :Ḣ, :H, :oc0_A, :oc1_A, :oc2_A, Symbol("2")]
 
   TVar = 1
   incl = [5]
 
-  Op1 = 5
-  src = [2, 4, 3, 6, 9]
-  tgt = [7, 8, 5, 5, 1]
-  op1 = [:b, :d, :c, :∂ₜ, :avg2]
+  Op1 = 4
+  src = [2, 4, 3, 6]
+  tgt = [7, 8, 5, 5]
+  op1 = [:b, :d, :c, :∂ₜ]
+
+  Op2 = 1
+  proj1 = [9]
+  proj2 = [10]
+  res = [1]
+  op2 = [:/]
 
   Σ = 1
   sum = [9]
@@ -427,24 +458,27 @@ BinTest = makePerfectBinaryDeca(h)
 BinTestRes = average_rewrite(BinTest)
 
 BinTestExpected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 76
-  type = [:Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
-  :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
-  :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1]
-  name = [Symbol("•1"), Symbol("•2"), Symbol("•3"), Symbol("•4"), Symbol("•5"), Symbol("•6"), Symbol("•7"), Symbol("•8"), Symbol("•9"), Symbol("•10"), Symbol("•11"), Symbol("•12"), Symbol("•13"), Symbol("•14"), Symbol("•15"), Symbol("•16"), Symbol("•17"), Symbol("•18"), Symbol("•19"), Symbol("•20"), Symbol("•21"), Symbol("•22"), Symbol("•23"), Symbol("•24"), Symbol("•25"), Symbol("•26"), Symbol("•27"), Symbol("•28"), Symbol("•29"), Symbol("•30"), Symbol("•31"), Symbol("oc0_•1"), Symbol("oc1_•1"), Symbol("oc2_•1"), Symbol("oc0_•2"), Symbol("oc1_•2"), Symbol("oc2_•2"), Symbol("oc0_•3"), Symbol("oc1_•3"), Symbol("oc2_•3"), Symbol("oc0_•4"), Symbol("oc1_•4"), Symbol("oc2_•4"), Symbol("oc0_•5"), Symbol("oc1_•5"), Symbol("oc2_•5"), Symbol("oc0_•6"), Symbol("oc1_•6"), Symbol("oc2_•6"), Symbol("oc0_•7"), Symbol("oc1_•7"), Symbol("oc2_•7"), Symbol("oc0_•8"), Symbol("oc1_•8"), Symbol("oc2_•8"), Symbol("oc0_•9"), Symbol("oc1_•9"), Symbol("oc2_•9"), Symbol("oc0_•10"), Symbol("oc1_•10"), Symbol("oc2_•10"), Symbol("oc0_•11"), Symbol("oc1_•11"), Symbol("oc2_•11"), Symbol("oc0_•12"), Symbol("oc1_•12"), Symbol("oc2_•12"), Symbol("oc0_•13"), Symbol("oc1_•13"), Symbol("oc2_•13"), Symbol("oc0_•14"), Symbol("oc1_•14"), Symbol("oc2_•14"), Symbol("oc0_•15"), Symbol("oc1_•15"), Symbol("oc2_•15")]
+  Var = 91
+  type = [:Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal, :Form1, :Form1, :Form1, :Literal]
+  name = [Symbol("•1"), Symbol("•2"), Symbol("•3"), Symbol("•4"), Symbol("•5"), Symbol("•6"), Symbol("•7"), Symbol("•8"), Symbol("•9"), Symbol("•10"), Symbol("•11"), Symbol("•12"), Symbol("•13"), Symbol("•14"), Symbol("•15"), Symbol("•16"), Symbol("•17"), Symbol("•18"), Symbol("•19"), Symbol("•20"), Symbol("•21"), Symbol("•22"), Symbol("•23"), Symbol("•24"), Symbol("•25"), Symbol("•26"), Symbol("•27"), Symbol("•28"), Symbol("•29"), Symbol("•30"), Symbol("•31"), Symbol("oc0_•1"), Symbol("oc1_•1"), Symbol("oc2_•1"), Symbol("2"), Symbol("oc0_•2"), Symbol("oc1_•2"), Symbol("oc2_•2"), Symbol("2"), Symbol("oc0_•3"), Symbol("oc1_•3"), Symbol("oc2_•3"), Symbol("2"), Symbol("oc0_•4"), Symbol("oc1_•4"), Symbol("oc2_•4"), Symbol("2"), Symbol("oc0_•5"), Symbol("oc1_•5"), Symbol("oc2_•5"), Symbol("2"), Symbol("oc0_•6"), Symbol("oc1_•6"), Symbol("oc2_•6"), Symbol("2"), Symbol("oc0_•7"), Symbol("oc1_•7"), Symbol("oc2_•7"), Symbol("2"), Symbol("oc0_•8"), Symbol("oc1_•8"), Symbol("oc2_•8"), Symbol("2"), Symbol("oc0_•9"), Symbol("oc1_•9"), Symbol("oc2_•9"), Symbol("2"), Symbol("oc0_•10"), Symbol("oc1_•10"), Symbol("oc2_•10"), Symbol("2"), Symbol("oc0_•11"), Symbol("oc1_•11"), Symbol("oc2_•11"), Symbol("2"), Symbol("oc0_•12"), Symbol("oc1_•12"), Symbol("oc2_•12"), Symbol("2"), Symbol("oc0_•13"), Symbol("oc1_•13"), Symbol("oc2_•13"), Symbol("2"), Symbol("oc0_•14"), Symbol("oc1_•14"), Symbol("oc2_•14"), Symbol("2"), Symbol("oc0_•15"), Symbol("oc1_•15"), Symbol("oc2_•15"), Symbol("2")]
 
 
-  Op1 = 45
-  src = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76]
-  tgt = [32, 35, 38, 41, 44, 47, 50, 53, 56, 59, 62, 65, 68, 71, 74, 33, 36, 39, 42, 45, 48, 51, 54, 57, 60, 63, 66, 69, 72, 75, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
-  op1 = [Symbol("op1"), Symbol("op2"), Symbol("op3"), Symbol("op4"), Symbol("op5"), Symbol("op6"), Symbol("op7"), Symbol("op8"), Symbol("op9"), Symbol("op10"), Symbol("op11"), Symbol("op12"), Symbol("op13"), Symbol("op14"), Symbol("op15"), Symbol("op16"), Symbol("op17"), Symbol("op18"), Symbol("op19"), Symbol("op20"), Symbol("op21"), Symbol("op22"), Symbol("op23"), Symbol("op24"), Symbol("op25"), Symbol("op26"), Symbol("op27"), Symbol("op28"), Symbol("op29"), Symbol("op30"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2")]
+  Op1 = 30
+  src = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31]
+  tgt = [32, 36, 40, 44, 48, 52, 56, 60, 64, 68, 72, 76, 80, 84, 88, 33, 37, 41, 45, 49, 53, 57, 61, 65, 69, 73, 77, 81, 85, 89]
+  op1 = [Symbol("op1"), Symbol("op2"), Symbol("op3"), Symbol("op4"), Symbol("op5"), Symbol("op6"), Symbol("op7"), Symbol("op8"), Symbol("op9"), Symbol("op10"), Symbol("op11"), Symbol("op12"), Symbol("op13"), Symbol("op14"), Symbol("op15"), Symbol("op16"), Symbol("op17"), Symbol("op18"), Symbol("op19"), Symbol("op20"), Symbol("op21"), Symbol("op22"), Symbol("op23"), Symbol("op24"), Symbol("op25"), Symbol("op26"), Symbol("op27"), Symbol("op28"), Symbol("op29"), Symbol("op30")]
 
+  Op2 = 15
+  proj1 = [34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90]
+  proj2 = [35, 39, 43, 47, 51, 55, 59, 63, 67, 71, 75, 79, 83, 87, 91]
+  res = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+  op2 = [:/, :/, :/, :/, :/, :/, :/, :/, :/, :/, :/, :/, :/, :/, :/]
 
   Σ = 15
-  sum = [34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76]
+  sum = [34, 38, 42, 46, 50, 54, 58, 62, 66, 70, 74, 78, 82, 86, 90]
 
   Summand = 30
-  summand = [32, 33, 35, 36, 38, 39, 41, 42, 44, 45, 47, 48, 50, 51, 53, 54, 56, 57, 59, 60, 62, 63, 65, 66, 68, 69, 71, 72, 74, 75]
+  summand = [32, 33, 36, 37, 40, 41, 44, 45, 48, 49, 52, 53, 56, 57, 60, 61, 64, 65, 68, 69, 72, 73, 76, 77, 80, 81, 84, 85, 88, 89]
   summation = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]
 end
 

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -55,8 +55,8 @@ Test1Res = average_rewrite(Test1)
 
 Test1Expected = @acset SummationDecapode{Any, Any, Symbol} begin
   Var = 6
-  type = [:Form0, :Form1, :Form2, :Form0, :Form1, :Form2]
-  name = [:D₁, :D₂, :F, Symbol("••1"), Symbol("••2"), Symbol("••sum0")]
+  type = [:Form0, :Form1, :Form2, :Form2, :Form2, :Form2]
+  name = [:D₁, :D₂, :F, :oc0_F, :oc1_F, :oc2_F]
 
   Op1 = 3
   src = [1, 2, 6]
@@ -94,22 +94,20 @@ Test2Res = average_rewrite(Test2)
 Test2Expected = @acset SummationDecapode{Any, Any, Symbol} begin
   Var = 11
 
-  type = [:Form0, :Form0, :Form1, :Form0, :Form0, 
-  :Form1, :Form1, :Form1, :Form1, :Form1, :Form1]
+  type = [:Form0, :Form0, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1]
 
-  name = [:C₁, :C₂, :D₁, Symbol("••1"), Symbol("••2"), Symbol("••sum0"), 
-  :D₂, :F, Symbol("••3"), Symbol("••4"), Symbol("••sum1")]
+  name = [:C₁, :C₂, :D₁, :D₂, :F, :oc0_D₁, :oc1_D₁, :oc2_D₁, :oc0_F, :oc1_F, :oc2_F]
 
   Op1 = 6
-  src = [1, 2, 6, 3, 7, 11]
-  tgt = [4, 5, 3, 9, 10, 8]
-  op1 = [:d₀, :d₀, :avg2, :c₁, :c₂, :avg2]
+  src = [1, 2, 3, 4, 8, 11]
+  tgt = [6, 7, 9, 10, 3, 5]
+  op1 = [:d₀, :d₀, :c₁, :c₂, :avg2, :avg2]
 
   Σ = 2
-  sum = [6, 11]
+  sum = [8, 11]
 
   Summand = 4
-  summand = [4, 5, 9, 10]
+  summand = [6, 7, 9, 10]
   summation = [1, 1, 2, 2]
 end
 
@@ -135,31 +133,29 @@ Test3 = SummationDecapode(parse_decapode(DecaTest3))
 Test3Res = average_rewrite(Test3)
 
 Test3Expected = @acset SummationDecapode{Any, Any, Symbol} begin
-  Var = 14
+  Var = 12
 
-  type = Any[:Form2, :Form2, :Form0, :Form0, :Form2, :Form2, 
-  :Form2, :Form0, :Form0, :Form2, :Form0, :Form0, :Form2, :Form1]
+  type = [:Form0, :Form0, :Form0, :Form0, :Form1, :Form2, :Form2,  :Form2,  :Form2,  :Form2,  :Form2,  :Form2]
 
-  name = [:Temp_0, :Temp_1, :C, :D, :G, Symbol("••1"), Symbol("••2"), 
-  Symbol("••3"), Symbol("••4"), Symbol("••sum0"), :A, :B, :F, :E]
+  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G]
 
-  Op1 = 5
-  src = [1, 2, 3, 4, 10]
-  tgt = [6, 7, 8, 9, 5]
-  op1 = [:temp, :temp, :k, :t, :avg4]
+  Op1 = 3
+  src = [3, 4, 12]
+  tgt = [8, 9, 7]
+  op1 = [:k, :t, :avg4]
 
   Op2 = 1
-  proj1 = [11]
-  proj2 = [12]
-  res = [1]
+  proj1 = [1]
+  proj2 = [2]
+  res = [10]
   op2 = [:∧]
 
   Σ = 2
-  sum = [10, 2]
+  sum = [11, 12]
 
   Summand = 6
-  summand = [6, 7, 8, 9, 13, 14]
-  summation = [1, 1, 1, 1, 2, 2]
+  summand = [6, 5, 8, 9, 10, 11]
+  summation = [1, 1, 2, 2, 2, 2]
 end
 
 @test Test3Res == Test3Expected
@@ -179,8 +175,8 @@ Test4Res = average_rewrite(Test4)
 
 Test4Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 6
-  type = Any[:Form0, :Form1, :Form0, :Form0, :Form0, :Form1] 
-  name = [:C, :D, Symbol("••1"), Symbol("••2"), Symbol("••3"), Symbol("••sum0")]
+  type = [:Form0, :Form1, :Form1, :Form1, :Form1, :Form1] 
+  name = [:C, :D, :oc0_D, :oc1_D, :oc2_D, :oc3_D]
 
   Op1 = 4
   src = [1, 1, 1, 6]
@@ -220,14 +216,14 @@ Test5Res = average_rewrite(Test5)
 
 Test5Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 14
-  type = Any[:Form0, :Form1, :Form2, :Form1, :Form0, :Form0, 
-  :Form2, :Form0, :Form1, :Form2, :Form1, :Form0, :Form0, :Form2]
-  name = [:F, :E, :D, :C, :B, :A, :G, Symbol("••1"), Symbol("••2"), Symbol("••3"), Symbol("••4"), Symbol("••5"), Symbol("••6"), Symbol("••sum0")]
+  type = [:Form0, :Form0, :Form1, :Form2, :Form1, :Form0, 
+  :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2, :Form2]
+  name = [:A, :B, :C, :D, :E, :F, :G, :oc0_G, :oc1_G, :oc2_G, :oc3_G, :oc4_G, :oc5_G, :oc6_G]
 
   Op1 = 7
-  src = [1, 2, 3, 4, 5, 6, 14]
+  src = [6, 5, 4, 3, 2, 1, 14]
   tgt = [8, 9, 10, 11, 12, 13, 7]
-  op1 = Any[:f, :e, :d, :c, :b, :a, :avg6]
+  op1 = [:f, :e, :d, :c, :b, :a, :avg6]
 
   Σ = 1
   sum = [14]
@@ -258,27 +254,27 @@ Test6 = SummationDecapode(parse_decapode(DecaTest6))
 Test6Res = average_rewrite(Test6)
 
 Test6Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 14
-  type = Any[:Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
-  :Form0, :Form2, :Form0, :Form1, :Form2, :Form1, :Form2, :Form0]
-  name = [:Temp_0, :Temp_1, :E, Symbol("••1"), Symbol("••2"), Symbol("••sum0"), :A, :F, Symbol("••3"), Symbol("••4"), Symbol("••sum1"), :B, :C, :D]
+  Var = 12
+  type = [:Form0, :Form1, :Form2, :Form0, :Form1, :Form2, 
+  :Form1, :Form1, :Form1, :Form2, :Form2, :Form2]
+  name = [:A, :B, :C, :D, :E, :F, :oc0_E, :oc1_E, :oc2_E, :oc0_F, :oc1_F, :oc2_F]
 
-  Op1 = 6
-  src = [1, 2, 6, 7, 3, 11]
-  tgt = [4, 5, 3, 9, 10, 8]
-  op1 = Any[:temp, :temp, :avg2, :k, :t, :avg2]
+  Op1 = 4
+  src = [1, 5, 9, 12]
+  tgt = [10, 11, 5, 6]
+  op1 = [:k, :t, :avg2, :avg2]
 
   Op2 = 2
-  proj1 = [12, 12]
-  proj2 = [13, 14]
-  res = [1, 2]
-  op2 = Any[:p, :q]
+  proj1 = [2, 2]
+  proj2 = [3, 4]
+  res = [7, 8]
+  op2 = [:p, :q]
 
   Σ = 2
-  sum = [6, 11]
+  sum = [9, 12]
 
   Summand = 4
-  summand = [4, 5, 9, 10]
+  summand = [7, 8, 10, 11]
   summation = [1, 1, 2, 2]
 end
 
@@ -301,22 +297,21 @@ Test7 = SummationDecapode(parse_decapode(DecaTest7))
 Test7Res = average_rewrite(Test7)
 
 Test7Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
-  Var = 11
-  type = Any[:Form2, :Form2, :Form2, :Form2, :Form2, :Form2, 
-  :Form0, :Form1, :Form2, :Form1, :Form0]
-  name = [:Temp_0, :Temp_1, :F, Symbol("••1"), Symbol("••2"), Symbol("••sum0"), :A, :B, :C, :D, :E]
+  Var = 9
+  type = [:Form0, :Form1, :Form2, :Form1, :Form0, :Form2, :Form2, :Form2, :Form2]
+  name = [:A, :B, :C, :D, :E, :F, :oc0_F, :oc1_F, :oc2_F]
 
-  Op1 = 3
-  src = [1, 2, 6]
-  tgt = [4, 5, 3]
-  op1 = Any[:temp, :temp, :avg2]
+  Op1 = 1
+  src = [9]
+  tgt = [6]
+  op1 = [:avg2]
 
   Σ = 3
-  sum = [6, 1, 2]
+  sum = [7, 8, 9]
 
   Summand = 7
-  summand = [4, 5, 7, 8, 9, 10, 11]
-  summation = [1, 1, 2, 2, 3, 3, 3]
+  summand = [1, 2, 3, 4, 5, 7, 8]
+  summation = [1, 1, 2, 2, 2, 3, 3]
 end
 
 @test Test7Res == Test7Expected
@@ -337,7 +332,7 @@ Test8Res = average_rewrite(Test8)
 
 Test8Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 3
-  type = Any[:Form1, :Form2, :Form0]
+  type = [:Form1, :Form2, :Form0]
   name = [:D₁, :D₂, :F]
 
   TVar = 1
@@ -346,7 +341,7 @@ Test8Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Op1 = 2
   src = [1, 2]
   tgt = [3, 3]
-  op1 = Any[:∂ₜ, :c₂]
+  op1 = [:∂ₜ, :c₂]
 end
 
 @test Test8Res == Test8Expected
@@ -389,23 +384,22 @@ Test10Res = average_rewrite(Test10)
 
 Test10Expected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 9
-  type = Any[:Form0, :Form0, :Form0, :Form0, :Form0, :Form0, 
-  :Form0, :Form2, :Form2]
-  name = [:B, :D, :A, Symbol("••1"), Symbol("••2"), Symbol("••sum0"), :C, :Ḣ, :H]
+  type = [:Form0, :Form0, :Form0, :Form0, :Form2, :Form2, :Form0, :Form0, :Form0]
+  name = [:A, :B, :C, :D, :Ḣ, :H, :oc0_A, :oc1_A, :oc2_A]
 
   TVar = 1
-  incl = [8]
+  incl = [5]
 
   Op1 = 5
-  src = [1, 2, 6, 7, 9]
-  tgt = [4, 5, 3, 8, 8]
-  op1 = Any[:b, :d, :avg2, :c, :∂ₜ]
+  src = [2, 4, 3, 6, 9]
+  tgt = [7, 8, 5, 5, 1]
+  op1 = [:b, :d, :c, :∂ₜ, :avg2]
 
   Σ = 1
-  sum = [6]
+  sum = [9]
 
   Summand = 2
-  summand = [4, 5]
+  summand = [7, 8]
   summation = [1, 1]
 end
 
@@ -434,26 +428,24 @@ BinTestRes = average_rewrite(BinTest)
 
 BinTestExpected = @acset SummationDecapode{Any, Any, Symbol}  begin
   Var = 76
-  type = Any[:Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
+  type = [:Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
   :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, 
   :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1, :Form1]
-  name = [Symbol("•2"), Symbol("•3"), Symbol("•1"), Symbol("••1"), Symbol("••2"), Symbol("••sum0"), Symbol("•4"), Symbol("•5"), Symbol("••3"), Symbol("••4"), Symbol("••sum1"), Symbol("•6"), Symbol("•7"), Symbol("••5"), Symbol("••6"), Symbol("••sum2"), Symbol("•8"), Symbol("•9"), Symbol("••7"), Symbol("••8"), Symbol("••sum3"), Symbol("•10"), Symbol("•11"), Symbol("••9"), Symbol("••10"), Symbol("••sum4"), Symbol("•12"), Symbol("•13"), Symbol("••11"), Symbol("••12"), Symbol("••sum5"), Symbol("•14"), Symbol("•15"), Symbol("••13"), 
-  Symbol("••14"), Symbol("••sum6"), Symbol("•16"), Symbol("•17"), Symbol("••15"), Symbol("••16"), Symbol("••sum7"), Symbol("•18"), Symbol("•19"), Symbol("••17"), Symbol("••18"), Symbol("••sum8"), Symbol("•20"), Symbol("•21"), Symbol("••19"), Symbol("••20"), Symbol("••sum9"), Symbol("•22"), Symbol("•23"), Symbol("••21"), Symbol("••22"), Symbol("••sum10"), Symbol("•24"), Symbol("•25"), Symbol("••23"), Symbol("••24"), Symbol("••sum11"), Symbol("•26"), Symbol("•27"), Symbol("••25"), Symbol("••26"), Symbol("••sum12"), Symbol("•28"), Symbol("•29"), Symbol("••27"), Symbol("••28"), Symbol("••sum13"), Symbol("•30"), Symbol("•31"), Symbol("••29"), Symbol("••30"), Symbol("••sum14")]
+  name = [Symbol("•1"), Symbol("•2"), Symbol("•3"), Symbol("•4"), Symbol("•5"), Symbol("•6"), Symbol("•7"), Symbol("•8"), Symbol("•9"), Symbol("•10"), Symbol("•11"), Symbol("•12"), Symbol("•13"), Symbol("•14"), Symbol("•15"), Symbol("•16"), Symbol("•17"), Symbol("•18"), Symbol("•19"), Symbol("•20"), Symbol("•21"), Symbol("•22"), Symbol("•23"), Symbol("•24"), Symbol("•25"), Symbol("•26"), Symbol("•27"), Symbol("•28"), Symbol("•29"), Symbol("•30"), Symbol("•31"), Symbol("oc0_•1"), Symbol("oc1_•1"), Symbol("oc2_•1"), Symbol("oc0_•2"), Symbol("oc1_•2"), Symbol("oc2_•2"), Symbol("oc0_•3"), Symbol("oc1_•3"), Symbol("oc2_•3"), Symbol("oc0_•4"), Symbol("oc1_•4"), Symbol("oc2_•4"), Symbol("oc0_•5"), Symbol("oc1_•5"), Symbol("oc2_•5"), Symbol("oc0_•6"), Symbol("oc1_•6"), Symbol("oc2_•6"), Symbol("oc0_•7"), Symbol("oc1_•7"), Symbol("oc2_•7"), Symbol("oc0_•8"), Symbol("oc1_•8"), Symbol("oc2_•8"), Symbol("oc0_•9"), Symbol("oc1_•9"), Symbol("oc2_•9"), Symbol("oc0_•10"), Symbol("oc1_•10"), Symbol("oc2_•10"), Symbol("oc0_•11"), Symbol("oc1_•11"), Symbol("oc2_•11"), Symbol("oc0_•12"), Symbol("oc1_•12"), Symbol("oc2_•12"), Symbol("oc0_•13"), Symbol("oc1_•13"), Symbol("oc2_•13"), Symbol("oc0_•14"), Symbol("oc1_•14"), Symbol("oc2_•14"), Symbol("oc0_•15"), Symbol("oc1_•15"), Symbol("oc2_•15")]
+
 
   Op1 = 45
-  src = [1, 2, 6, 7, 8, 11, 12, 13, 16, 17, 18, 21, 22, 23, 26, 27, 28, 31, 32, 33, 36, 37, 38, 41, 42, 43, 46, 47, 48, 
-  51, 52, 53, 56, 57, 58, 61, 62, 63, 66, 67, 68, 71, 72, 73, 76]
-  tgt = [4, 5, 3, 9, 10, 1, 14, 15, 2, 19, 20, 7, 24, 25, 8, 
-  29, 30, 12, 34, 35, 13, 39, 40, 17, 44, 45, 18, 49, 50, 22, 54, 55, 23, 59, 60, 27, 64, 65, 28, 69, 70, 32, 74, 75, 33]
-  op1 = Any[:op1, :op16, :avg2, :op2, :op17, :avg2, :op3, :op18, :avg2, :op4, :op19, :avg2, :op5, :op20, :avg2, :op6, :op21, :avg2, :op7, :op22, :avg2, :op8, :op23, :avg2, :op9, :op24, :avg2, :op10, :op25, :avg2, :op11, :op26, :avg2, :op12, :op27, :avg2, :op13, :op28, :avg2, :op14, :op29, :avg2, 
-  :op15, :op30, :avg2]
+  src = [2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76]
+  tgt = [32, 35, 38, 41, 44, 47, 50, 53, 56, 59, 62, 65, 68, 71, 74, 33, 36, 39, 42, 45, 48, 51, 54, 57, 60, 63, 66, 69, 72, 75, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+  op1 = [Symbol("op1"), Symbol("op2"), Symbol("op3"), Symbol("op4"), Symbol("op5"), Symbol("op6"), Symbol("op7"), Symbol("op8"), Symbol("op9"), Symbol("op10"), Symbol("op11"), Symbol("op12"), Symbol("op13"), Symbol("op14"), Symbol("op15"), Symbol("op16"), Symbol("op17"), Symbol("op18"), Symbol("op19"), Symbol("op20"), Symbol("op21"), Symbol("op22"), Symbol("op23"), Symbol("op24"), Symbol("op25"), Symbol("op26"), Symbol("op27"), Symbol("op28"), Symbol("op29"), Symbol("op30"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2"), Symbol("avg2")]
+
 
   Σ = 15
-  sum = [6, 11, 16, 21, 26, 31, 36, 41, 46, 51, 56, 61, 66, 71, 76]
+  sum = [34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76]
 
   Summand = 30
-  summand = [4, 5, 9, 10, 14, 15, 19, 20, 24, 25, 29, 30, 34, 35, 39, 40, 44, 45, 49, 50, 54, 55, 59, 60, 64, 65, 69, 70, 74, 75]
-  summation = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]    
+  summand = [32, 33, 35, 36, 38, 39, 41, 42, 44, 45, 47, 48, 50, 51, 53, 54, 56, 57, 59, 60, 62, 63, 65, 66, 68, 69, 71, 72, 74, 75]
+  summation = [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15]
 end
 
 @test BinTestRes == BinTestExpected


### PR DESCRIPTION
Close #30 

Instead of deleting this feature or tracking updates to AlgebraicRewriting, we can use the familiar ACSet editing idioms to implement this feature “manually”.