### PR TITLE
Bugfix to cm/symbolictypes

### DIFF
--- a/src/symbolictheoryutils.jl
+++ b/src/symbolictheoryutils.jl
@@ -106,11 +106,13 @@ macro operator(head, body)
     result = quote end
     
     # construct the function on basic symbolics
+    argnames = [gensym(:x) for _ in 1:arity]
+    argclaus = [:($a::Symbolic) for a in argnames]
     push!(result.args, quote
         @nospecialize
-        function $f(args...)
-            s = promote_symtype($f, args...)
-            SymbolicUtils.Term{s}($f, [args...])
+        function $f($(argclaus...))
+            s = promote_symtype($f, $(argnames...))
+            SymbolicUtils.Term{s}($f, Any[$(argnames...)])
         end
         export $f
     end)


### PR DESCRIPTION
If you used the operator macro with an existing function imported from another module like Base, the operator macro would shadow it because of untyped splatting methods that were being generated.