### PR TITLE
Add inference rule for PD sharp in 1D

### DIFF
--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -35,6 +35,7 @@ op1_inf_rules_1D = [
 
   # Rules for ♯.
   (src_type = :Form1, tgt_type = :PVF, op_names = [:♯, :♯ᵖᵖ]),
+  (src_type = :Form1, tgt_type = :DVF, op_names = [:♯, :♯ᵖᵈ]),
   (src_type = :DualForm1, tgt_type = :DVF, op_names = [:♯, :♯ᵈᵈ]),
 
   # Rules for ♭.


### PR DESCRIPTION
[CombinatorialSpaces PR 136](https://github.com/AlgebraicJulia/CombinatorialSpaces.jl/pull/136) introduced 1D sharp operators. [Decapodes PR 306](https://github.com/AlgebraicJulia/Decapodes.jl/pull/306) added bindings for code emission. This current PR adds a type inference rule for the new Primal 1-Form - Dual Vectorfield sharp operation in 1D.