### PR TITLE
Replacing `rvrv` code pattern

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,8 @@
 name = "DiagrammaticEquations"
 uuid = "6f00c28b-6bed-4403-80fa-30e0dc12f317"
 license = "MIT"
-authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson", "Luke Morris", "George Rauta", "Matt Cuffaro"]
 version = "0.2.3"
+authors = ["James Fairbanks", "Andrew Baas", "Evan Patterson", "Luke Morris", "George Rauta", "Matt Cuffaro"]
 
 [deps]
 ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
@@ -22,7 +22,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 ACSets = "0.2 - 0.2.21, ~0.2.23"
 Catlab = "0.17.3"
 Colors = "0.12.11, 0.13.0"
-DataStructures = "0.18.20"
+DataStructures = "0.18.22"
 LinearAlgebra = "1.10, 1.11"
 MLStyle = "0.4.17"
 PEG = "1"

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -348,6 +348,9 @@ function find_chains(d::SummationDecapode;
     black_list::Set{Symbol} = Set{Symbol}())
   chains = []
   visited = falses(nparts(d, :Op1))
+  @show infer_states(d)
+  @show filter(!isnothing, infer_states(d))
+  @show Where(:op1, collect(black_list))
   chain_starts = (From(:Op1) |> 
   Where(:src, d[:res] ∪ d[:sum] ∪ filter(!isnothing, infer_states(d))) |
   Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -351,6 +351,8 @@ function find_chains(d::SummationDecapode;
   @show infer_states(d)
   @show filter(!isnothing, infer_states(d))
   @show Where(:op1, collect(black_list))
+  @show Where(:op1, collect(black_list)).rhs
+  @show Where(:op1, collect(black_list)).rhs(d)
   chain_starts = (From(:Op1) |> 
   Where(:src, d[:res] ∪ d[:sum] ∪ filter(!isnothing, infer_states(d))) |
   Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -348,14 +348,9 @@ function find_chains(d::SummationDecapode;
     black_list::Set{Symbol} = Set{Symbol}())
   chains = []
   visited = falses(nparts(d, :Op1))
-  @show infer_states(d)
-  @show filter(!isnothing, infer_states(d))
-  @show Where(:op1, collect(black_list))
-  @show Where(:op1, collect(black_list)).rhs
-  @show Where(:op1, collect(black_list)).rhs(d)
   chain_starts = (From(:Op1) |> 
   Where(:src, d[:res] ∪ d[:sum] ∪ filter(!isnothing, infer_states(d))) |
-  Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)
+  Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)[:Op1]
 
   passes_white_list(x) = isempty(white_list) ? true : x ∈ white_list
   passes_black_list(x) = x ∉ black_list

--- a/src/acset.jl
+++ b/src/acset.jl
@@ -1,6 +1,8 @@
 using Catlab.DenseACSets
 
 using DataStructures
+using ACSets.InterTypes
+using ACSets.Query: From, Where
 
 import Base.show
 
@@ -346,13 +348,9 @@ function find_chains(d::SummationDecapode;
     black_list::Set{Symbol} = Set{Symbol}())
   chains = []
   visited = falses(nparts(d, :Op1))
-  # TODO: Re-write this without two reduce-vcats.
-  rvrv(x) = reduce(vcat, reduce(vcat, x))
-  chain_starts = unique(rvrv(
-    [incident(d, Vector{Int64}(filter(i -> !isnothing(i), infer_states(d))), :src),
-     incident(d, d[:res], :src),
-     incident(d, d[:sum], :src),
-     incident(d, d[Base.collect(Iterators.flatten(incident(d, Base.collect(black_list), :op1))), :tgt], :src)]))
+  chain_starts = (From(:Op1) |> 
+  Where(:src, d[:res] ∪ d[:sum] ∪ filter(!isnothing, infer_states(d))) |
+  Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)
 
   passes_white_list(x) = isempty(white_list) ? true : x ∈ white_list
   passes_black_list(x) = x ∉ black_list


### PR DESCRIPTION
This PR addresses a TODO in `acsets.jl` for replacing an array of `incident` calls with an ACSet query.
```julia
chain_starts = (From(:Op1) |> 
  Where(:src, d[:res] ∪ d[:sum] ∪ filter(!isnothing, infer_states(d))) |
  Where(:src, From(:Op1=>:tgt) |> Where(:op1, collect(black_list))))(d)
```


This PR depends on [FunSQL-like querying an ACSet](https://github.com/AlgebraicJulia/ACSets.jl/pull/163).