### PR TITLE
Adding support for 3D operators

### DIFF
--- a/src/acset.jl
+++ b/src/acset.jl
@@ -159,13 +159,13 @@ end
 
 # A collection of DecaType getters
 # TODO: This should be replaced by using a type hierarchy
-const ALL_TYPES = [:Form0, :Form1, :Form2, :DualForm0, :DualForm1, :DualForm2,
+const ALL_TYPES = [:Form0, :Form1, :Form2, :Form3, :DualForm0, :DualForm1, :DualForm2, :DualForm3,
                    :PVF, :DVF,
                    :Literal, :Parameter, :Constant, :infer]
 
-const FORM_TYPES = [:Form0, :Form1, :Form2, :DualForm0, :DualForm1, :DualForm2]
-const PRIMALFORM_TYPES = [:Form0, :Form1, :Form2]
-const DUALFORM_TYPES = [:DualForm0, :DualForm1, :DualForm2]
+const FORM_TYPES = [:Form0, :Form1, :Form2, :Form3, :DualForm0, :DualForm1, :DualForm2, :DualForm3]
+const PRIMALFORM_TYPES = [:Form0, :Form1, :Form2, :Form3]
+const DUALFORM_TYPES = [:DualForm0, :DualForm1, :DualForm2, :DualForm3]
 
 const VECTORFIELD_TYPES = [:PVF, :DVF]
 

--- a/src/deca/Deca.jl
+++ b/src/deca/Deca.jl
@@ -3,6 +3,7 @@ module Deca
 using DataStructures
 using ..DiagrammaticEquations
 using Catlab
+using MLStyle
 
 using Reexport
 

--- a/src/deca/ThDEC.jl
+++ b/src/deca/ThDEC.jl
@@ -169,7 +169,12 @@ isForm2(x) = @match symtype(x) begin
     _ => false
 end
 
-export isDualForm, isForm0, isForm1, isForm2
+isForm3(x) = @match symtype(x) begin
+    PatFormParams([3,_,_,_]) => true
+    _ => false
+end
+
+export isDualForm, isForm0, isForm1, isForm2, isForm3
 
 # ###############################
 # OPERATORS
@@ -187,7 +192,7 @@ export isDualForm, isForm0, isForm1, isForm2
     end
 end
 
-@alias (d₀, d₁) => d
+@alias (d₀, d₁, d₂, dual_d₀, dual_d₁, dual_d₂, d̃₀, d̃₁, d̃₂) => d
 
 @operator ★(S)::DECQuantity begin
     @match S begin
@@ -198,7 +203,7 @@ end
 end
 
 # TODO in orthodox Decapodes, these are type-specific.
-@alias (★₀, ★₁, ★₂, ★₀⁻¹, ★₁⁻¹, ★₂⁻¹) => ★
+@alias (★₀, ★₁, ★₂, ★₃, ★₀⁻¹, ★₁⁻¹, ★₂⁻¹, ★₃⁻¹, ⋆₀, ⋆₁, ⋆₂, ⋆₃, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹, ⋆₃⁻¹) => ★
 
 @operator Δ(S)::DECQuantity begin
     @match S begin
@@ -209,9 +214,10 @@ end
     @rule Δ(~x::isForm0) => ★(d(★(d(~x))))
     @rule Δ(~x::isForm1) => ★(d(★(d(~x)))) + d(★(d(★(~x))))
     @rule Δ(~x::isForm2) => d(★(d(★(~x))))
+    @rule Δ(~x::isForm3) => d(★(d(★(~x))))
 end
 
-@alias (Δ₀, Δ₁, Δ₂) => Δ
+@alias (Δ₀, Δ₁, Δ₂, Δ₃) => Δ
 
 # TODO: Determine what we need to do for .+
 @operator +(S1, S2)::DECQuantity begin
@@ -243,7 +249,7 @@ end
     end
 end
 
-@alias (∧₀₀, ∧₀₁, ∧₁₀, ∧₁₁, ∧₀₂, ∧₂₀) => ∧
+@alias (∧₀₀, ∧₀₁, ∧₁₀, ∧₁₁, ∧₀₂, ∧₂₀, ∧₀₃, ∧₃₀, ∧₁₂, ∧₂₁) => ∧
 
 @operator ∧(S1, S2)::DECQuantity begin
     @match (S1, S2) begin
@@ -305,9 +311,11 @@ function SymbolicUtils.symtype(::Type{<:Quantity}, qty::Symbol, space::Symbol, d
         :Form0 => PrimalForm{0, space, dim}
         :Form1 => PrimalForm{1, space, dim}
         :Form2 => PrimalForm{2, space, dim}
+        :Form3 => PrimalForm{3, space, dim}
         :DualForm0 => DualForm{0, space, dim}
         :DualForm1 => DualForm{1, space, dim}
         :DualForm2 => DualForm{2, space, dim}
+        :DualForm3 => DualForm{3, space, dim}
         :infer => InferredType
         _ => error("Received $qty which is not a valid type for Decapodes")
     end

--- a/src/deca/ThDEC.jl
+++ b/src/deca/ThDEC.jl
@@ -192,7 +192,11 @@ export isDualForm, isForm0, isForm1, isForm2, isForm3
     end
 end
 
-@alias (d₀, d₁, d₂, dual_d₀, dual_d₁, dual_d₂, d̃₀, d̃₁, d̃₂) => d
+@alias (
+    d₀, d₁, d₂,
+    dual_d₀, dual_d₁, dual_d₂,
+    d̃₀, d̃₁, d̃₂,
+) => d
 
 @operator ★(S)::DECQuantity begin
     @match S begin
@@ -203,7 +207,10 @@ end
 end
 
 # TODO in orthodox Decapodes, these are type-specific.
-@alias (★₀, ★₁, ★₂, ★₃, ★₀⁻¹, ★₁⁻¹, ★₂⁻¹, ★₃⁻¹, ⋆₀, ⋆₁, ⋆₂, ⋆₃, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹, ⋆₃⁻¹) => ★
+@alias (
+    ★₀, ★₁, ★₂, ★₃, ★₀⁻¹, ★₁⁻¹, ★₂⁻¹, ★₃⁻¹,
+    ⋆₀, ⋆₁, ⋆₂, ⋆₃, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹, ⋆₃⁻¹,
+) => ★
 
 @operator Δ(S)::DECQuantity begin
     @match S begin

--- a/src/deca/ThDEC.jl
+++ b/src/deca/ThDEC.jl
@@ -169,7 +169,12 @@ isForm2(x) = @match symtype(x) begin
     _ => false
 end
 
-export isDualForm, isForm0, isForm1, isForm2
+isForm3(x) = @match symtype(x) begin
+    PatFormParams([3,_,_,_]) => true
+    _ => false
+end
+
+export isDualForm, isForm0, isForm1, isForm2, isForm3
 
 # ###############################
 # OPERATORS
@@ -214,6 +219,7 @@ end
     @rule Δ(~x::isForm0) => ★(d(★(d(~x))))
     @rule Δ(~x::isForm1) => ★(d(★(d(~x)))) + d(★(d(★(~x))))
     @rule Δ(~x::isForm2) => d(★(d(★(~x))))
+    @rule Δ(~x::isForm3) => d(★(d(★(~x))))
 end
 
 @alias (Δ₀, Δ₁, Δ₂, Δ₃) => Δ

--- a/src/deca/ThDEC.jl
+++ b/src/deca/ThDEC.jl
@@ -169,12 +169,7 @@ isForm2(x) = @match symtype(x) begin
     _ => false
 end
 
-isForm3(x) = @match symtype(x) begin
-    PatFormParams([3,_,_,_]) => true
-    _ => false
-end
-
-export isDualForm, isForm0, isForm1, isForm2, isForm3
+export isDualForm, isForm0, isForm1, isForm2
 
 # ###############################
 # OPERATORS
@@ -193,9 +188,7 @@ export isDualForm, isForm0, isForm1, isForm2, isForm3
 end
 
 @alias (
-    d₀, d₁, d₂,
-    dual_d₀, dual_d₁, dual_d₂,
-    d̃₀, d̃₁, d̃₂,
+    d₀, d₁, d₂
 ) => d
 
 @operator ★(S)::DECQuantity begin
@@ -209,7 +202,7 @@ end
 # TODO in orthodox Decapodes, these are type-specific.
 @alias (
     ★₀, ★₁, ★₂, ★₃, ★₀⁻¹, ★₁⁻¹, ★₂⁻¹, ★₃⁻¹,
-    ⋆₀, ⋆₁, ⋆₂, ⋆₃, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹, ⋆₃⁻¹,
+    ⋆₀, ⋆₁, ⋆₂, ⋆₃, ⋆₀⁻¹, ⋆₁⁻¹, ⋆₂⁻¹, ⋆₃⁻¹
 ) => ★
 
 @operator Δ(S)::DECQuantity begin
@@ -221,7 +214,6 @@ end
     @rule Δ(~x::isForm0) => ★(d(★(d(~x))))
     @rule Δ(~x::isForm1) => ★(d(★(d(~x)))) + d(★(d(★(~x))))
     @rule Δ(~x::isForm2) => d(★(d(★(~x))))
-    @rule Δ(~x::isForm3) => d(★(d(★(~x))))
 end
 
 @alias (Δ₀, Δ₁, Δ₂, Δ₃) => Δ

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -9,19 +9,24 @@ op1_operators = [
   Rule(:Form0, :Form0, :∂ₜ, [:dt]),
   Rule(:Form1, :Form1, :∂ₜ, [:dt]),
   Rule(:Form2, :Form2, :∂ₜ, [:dt]),
+  Rule(:Form3, :Form3, :∂ₜ, [:dt]),
   Rule(:DualForm0, :DualForm0, :∂ₜ, [:dt]),
   Rule(:DualForm1, :DualForm1, :∂ₜ, [:dt]),
   Rule(:DualForm2, :DualForm2, :∂ₜ, [:dt]),
+  Rule(:DualForm3, :DualForm3, :∂ₜ, [:dt]),
 
   # Rules for d.
   Rule(:Form1, :Form0, :d₀, [:d]),
   Rule(:Form2, :Form1, :d₁, [:d]),
+  Rule(:Form3, :Form2, :d₂, [:d]),
   Rule(:DualForm1, :DualForm0, :dual_d₀, [:d, :d̃₀]),
   Rule(:DualForm2, :DualForm1, :dual_d₁, [:d, :d̃₁]),
+  Rule(:DualForm3, :DualForm2, :dual_d₂, [:d, :d̃₂]),
 
   # Rules for δ
   Rule(:Form0, :Form1, :δ₁, [:δ, :codif]),
   Rule(:Form1, :Form2, :δ₂, [:δ, :codif]),
+  Rule(:Form2, :Form3, :δ₃, [:δ, :codif]),
 
   # Rules for ♯
   Rule(:PVF, :Form1, :♯ᵖᵖ, [:♯]),
@@ -36,6 +41,7 @@ op1_operators = [
   Rule(:Form0, :Form0, :Δ₀, [:Δ, :∇², :lapl]),
   Rule(:Form1, :Form1, :Δ₁, [:Δ, :∇², :lapl]),
   Rule(:Form2, :Form2, :Δ₂, [:Δ, :∇², :lapl]),
+  Rule(:Form3, :Form3, :Δ₃, [:Δ, :∇², :lapl]),
 
   # Rules for Δᵈ
   Rule(:DualForm0, :DualForm0, :Δᵈ₀, [:Δ, :∇², :lapl]),
@@ -44,9 +50,11 @@ op1_operators = [
   Rule(:Form0, :Form0, :(-), [:neg]),
   Rule(:Form1, :Form1, :(-), [:neg]),
   Rule(:Form2, :Form2, :(-), [:neg]),
+  Rule(:Form3, :Form3, :(-), [:neg]),
   Rule(:DualForm0, :DualForm0, :(-), [:neg]),
   Rule(:DualForm1, :DualForm1, :(-), [:neg]),
   Rule(:DualForm2, :DualForm2, :(-), [:neg]),
+  Rule(:DualForm3, :DualForm3, :(-), [:neg]),
 
   # Rules for the averaging operator
   Rule(:Form1, :Form0, :avg₀₁, [:avg_01]),
@@ -75,6 +83,20 @@ op1_2D_bound_operators = [
   Rule(:Form2, :DualForm0, :⋆₂⁻¹, [:★, :⋆, :star, :star_inv])
 ]
 
+op1_3D_bound_operators = [
+
+  # Rules for ⋆
+  Rule(:DualForm3, :Form0, :⋆₀, [:★, :⋆, :star]),
+  Rule(:DualForm2, :Form1, :⋆₁, [:★, :⋆, :star]),
+  Rule(:DualForm1, :Form2, :⋆₂, [:★, :⋆, :star]),
+  Rule(:DualForm0, :Form3, :⋆₃, [:★, :⋆, :star]),
+  Rule(:Form0, :DualForm3, :⋆₀⁻¹, [:★, :⋆, :star, :star_inv]),
+  Rule(:Form1, :DualForm2, :⋆₁⁻¹, [:★, :⋆, :star, :star_inv]),
+  Rule(:Form2, :DualForm1, :⋆₂⁻¹, [:★, :⋆, :star, :star_inv]),
+  Rule(:Form3, :DualForm0, :⋆₃⁻¹, [:★, :⋆, :star, :star_inv])
+]
+
+
 op2_operators = [
   # Rules for ∧.
   Rule(:Form0, [:Form0, :Form0], :∧₀₀, [:∧, :wedge]),
@@ -83,11 +105,14 @@ op2_operators = [
   Rule(:Form2, [:Form1, :Form1], :∧₁₁, [:∧, :wedge]),
   Rule(:Form2, [:Form2, :Form0], :∧₂₀, [:∧, :wedge]),
   Rule(:Form2, [:Form0, :Form2], :∧₀₂, [:∧, :wedge]),
+  Rule(:Form3, [:Form2, :Form1], :∧₂₁, [:∧, :wedge]),
+  Rule(:Form3, [:Form1, :Form2], :∧₁₂, [:∧, :wedge]),
 
   # Rules for L.
   Rule(:DualForm0, [:Form1, :DualForm0], :L₀, [:L]),
   Rule(:DualForm1, [:Form1, :DualForm1], :L₁, [:L]),
   Rule(:DualForm2, [:Form1, :DualForm2], :L₂, [:L]),
+  Rule(:DualForm3, [:Form1, :DualForm3], :L₃, [:L]),
 
   # TODO: Make consistent with other Lie's
   Rule(:DualForm1, [:DualForm1, :DualForm1], :ℒ₁),
@@ -95,6 +120,8 @@ op2_operators = [
   # Rules for i.
   Rule(:DualForm0, [:Form1, :DualForm1], :i₁, [:i]),
   Rule(:DualForm1, [:Form1, :DualForm2], :i₂, [:i]),
+  Rule(:DualForm2, [:Form1, :DualForm3], :i₃, [:i]),
+
   Rule(:DualForm0, [:DualForm1, :DualForm1], :ι₁₁),
   Rule(:DualForm1, [:DualForm1, :DualForm2], :ι₁₂),
 
@@ -121,9 +148,14 @@ op2_operators = [
 # TODO: When SummationDecapodes are annotated with the degree of their space,
 # use dispatch to choose the correct set of rules.
 function default_operators(dim)
-  @assert 1 <= dim <= 2
+  @assert 1 <= dim <= 3
   metric_free = vcat(op1_operators, op2_operators)
-  return vcat(metric_free, dim == 1 ? op1_1D_bound_operators : op1_2D_bound_operators)
+  metric_bound = @match dim begin
+    1 => op1_1D_bound_operators
+    2 => op1_2D_bound_operators
+    3 => op1_3D_bound_operators
+  end
+  return vcat(metric_free, metric_bound)
 end
 
 infer_types!(d::SummationDecapode; dim = 2) =

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -107,6 +107,8 @@ op2_operators = [
   Rule(:Form2, [:Form0, :Form2], :∧₀₂, [:∧, :wedge]),
   Rule(:Form3, [:Form2, :Form1], :∧₂₁, [:∧, :wedge]),
   Rule(:Form3, [:Form1, :Form2], :∧₁₂, [:∧, :wedge]),
+  Rule(:Form3, [:Form3, :Form0], :∧₃₀, [:∧, :wedge]),
+  Rule(:Form3, [:Form0, :Form3], :∧₀₃, [:∧, :wedge]),
 
   # Rules for L.
   Rule(:DualForm0, [:Form1, :DualForm0], :L₀, [:L]),

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -2,7 +2,7 @@ using ..DiagrammaticEquations
 
 # TODO: You could write a method which auto-generates these rules given degree N.
 """
-These are the default rules used to do type inference/function resolution in the 1D/2D exterior calculus.
+These are the default rules used to do type inference/function resolution in the 1D/2D/3D exterior calculus.
 """
 op1_operators = [
   # Rules for ∂ₜ

--- a/test/decasymbolic.jl
+++ b/test/decasymbolic.jl
@@ -90,6 +90,10 @@ end
   @test !isForm2(u)
   @test !isForm2(a)
 
+  @test isForm3(h3)
+  @test !isForm3(u)
+  @test !isForm3(a)
+
   @test isDualForm(η)
   @test !isDualForm(u)
   @test !isDualForm(a)
@@ -152,6 +156,9 @@ end
     @test symtype(★₃(h3)) == PrimalForm{0, :X, 3}
     @test symtype(⋆₃(h3)) == PrimalForm{0, :X, 3}
     @test symtype(∧₂₁(η3, ω3)) == PrimalForm{3, :X, 3}
+
+    # Δ rewrite rule for 3-forms: only the d∘δ term survives since d(Form3)=0 in 3D
+    @test isequal(SymbolicUtils.Chain(rules(Δ, Val(1)))(Δ(h3)), d(★(d(★(h3)))))
 end
 
 @testset "Term Construction" begin

--- a/test/decasymbolic.jl
+++ b/test/decasymbolic.jl
@@ -21,6 +21,9 @@ h,    = @syms h::PrimalForm{2, :X, 2}
 
 u2,   = @syms u2::PrimalForm{0, :Y, 2}
 u3,   = @syms u3::PrimalForm{0, :X, 3}
+ω3,   = @syms ω3::PrimalForm{1, :X, 3}
+η3,   = @syms η3::PrimalForm{2, :X, 3}
+h3,   = @syms h3::PrimalForm{3, :X, 3}
 
 @testset "Symtypes" begin
 
@@ -138,6 +141,17 @@ end
 
     # test composition
     @test promote_symtype(d ∘ d, u) == PrimalForm{2, :X, 2}
+end
+
+@testset "3D Type and Alias Support" begin
+    @test symtype(Quantity, :Form3, :X, 3) == PrimalForm{3, :X, 3}
+    @test symtype(Quantity, :DualForm3, :X, 3) == DualForm{3, :X, 3}
+
+    @test symtype(d₂(η3)) == PrimalForm{3, :X, 3}
+    @test symtype(Δ₃(h3)) == PrimalForm{3, :X, 3}
+    @test symtype(★₃(h3)) == PrimalForm{0, :X, 3}
+    @test symtype(⋆₃(h3)) == PrimalForm{0, :X, 3}
+    @test symtype(∧₂₁(η3, ω3)) == PrimalForm{3, :X, 3}
 end
 
 @testset "Term Construction" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1210,6 +1210,68 @@ end
   @test_throws DecaTypeExeception type_check(HeatXfer)
   @test HeatXfer[12, :op2] == :*
   @test HeatXfer[40, :type] == :DualForm1 && HeatXfer[39, :type] == :Form1
+
+  deca_3d = @decapode begin
+    (P0::Form0)
+    (P1::Form1)
+    (P2::Form2)
+    (P3::Form3)
+
+    (D0::DualForm0)
+    (D1::DualForm1)
+    (D2::DualForm2)
+    (D3::DualForm3)
+
+    R1 == d(P2)
+    R2 == d(D2)
+
+    R3 == δ(P3)
+
+    R4 == Δ(P3)
+
+    R5 == -(P3)
+    R6 == -(D3)
+
+    R7 == ⋆(P0)
+    R8 == ⋆(P1)
+    R9 == ⋆(P2)
+    R10 == ⋆(P3)
+
+    R11 == ⋆(D0)
+    R12 == ⋆(D1)
+    R13 == ⋆(D2)
+    R14 == ⋆(D3)
+
+    R15 == ∂ₜ(P3)
+    R16 == ∂ₜ(D3)
+
+    R17 == ∧(P2, P1)
+    R18 == ∧(P1, P2)
+
+    R19 == L(P1, D3)
+    R20 == i(P1, D3)
+
+  end
+
+  infer_types!(deca_3d, dim=3)
+
+  @test deca_3d[deca_3d[1:4, :tgt], :type] == [:Form3, :DualForm3, :Form2, :Form3]
+  @test deca_3d[deca_3d[5:6, :tgt], :type] == [:Form3, :DualForm3]
+  @test deca_3d[deca_3d[7:10, :tgt], :type] == [:DualForm3, :DualForm2, :DualForm1, :DualForm0]
+  @test deca_3d[deca_3d[11:14, :tgt], :type] == [:Form3, :Form2, :Form1, :Form0]
+  @test deca_3d[deca_3d[15:16, :tgt], :type] == [:Form3, :DualForm3]
+  @test deca_3d[deca_3d[1:4, :res], :type] == [:Form3, :Form3, :DualForm3, :DualForm2]
+
+  @test type_check(deca_3d, dim=3)
+
+  resolve_overloads!(deca_3d, dim=3)
+
+  @test deca_3d[1:4, :op1] == [:d₂, :dual_d₂, :δ₃, :Δ₃]
+  @test deca_3d[5:6, :op1] == [:-, :-]
+  @test deca_3d[7:10, :op1] == [:⋆₀, :⋆₁, :⋆₂, :⋆₃]
+  @test deca_3d[11:14, :op1] == [:⋆₃⁻¹, :⋆₂⁻¹, :⋆₁⁻¹, :⋆₀⁻¹]
+  @test deca_3d[15:16, :op1] == [:∂ₜ, :∂ₜ]
+  @test deca_3d[1:4, :op2] == [:∧₂₁, :∧₁₂, :L₃, :i₃]
 end
 
 @testset "Compilation Transformation" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1251,6 +1251,9 @@ end
     R19 == L(P1, D3)
     R20 == i(P1, D3)
 
+    R21 == ∧(P3, P0)
+    R22 == ∧(P0, P3)
+
   end
 
   infer_types!(deca_3d, dim=3)
@@ -1260,7 +1263,7 @@ end
   @test deca_3d[deca_3d[7:10, :tgt], :type] == [:DualForm3, :DualForm2, :DualForm1, :DualForm0]
   @test deca_3d[deca_3d[11:14, :tgt], :type] == [:Form3, :Form2, :Form1, :Form0]
   @test deca_3d[deca_3d[15:16, :tgt], :type] == [:Form3, :DualForm3]
-  @test deca_3d[deca_3d[1:4, :res], :type] == [:Form3, :Form3, :DualForm3, :DualForm2]
+  @test deca_3d[deca_3d[1:6, :res], :type] == [:Form3, :Form3, :DualForm3, :DualForm2, :Form3, :Form3]
 
   @test type_check(deca_3d, dim=3)
 
@@ -1271,7 +1274,7 @@ end
   @test deca_3d[7:10, :op1] == [:⋆₀, :⋆₁, :⋆₂, :⋆₃]
   @test deca_3d[11:14, :op1] == [:⋆₃⁻¹, :⋆₂⁻¹, :⋆₁⁻¹, :⋆₀⁻¹]
   @test deca_3d[15:16, :op1] == [:∂ₜ, :∂ₜ]
-  @test deca_3d[1:4, :op2] == [:∧₂₁, :∧₁₂, :L₃, :i₃]
+  @test deca_3d[1:6, :op2] == [:∧₂₁, :∧₁₂, :L₃, :i₃, :∧₃₀, :∧₀₃]
 end
 
 @testset "Compilation Transformation" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1341,7 +1341,7 @@ R21   = ∧₃₀(P3, P0)
 R22   = ∧₀₃(P0, P3)
 """, "\n"))
   actual_lines = Set(split(sprint((io, x) -> DiagrammaticEquations.pprint(io, x), Term(deca_3d)), "\n"))
-  @test actual_lines == expected_lines
+  @test issetequal(actual_lines, expected_lines)
 end
 
 @testset "Compilation Transformation" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1277,24 +1277,15 @@ end
   end
 
   infer_types!(deca_3d, dim=3)
-
-  @test deca_3d[deca_3d[1:4, :tgt], :type] == [:Form3, :DualForm3, :Form2, :Form3]
-  @test deca_3d[deca_3d[5:6, :tgt], :type] == [:Form3, :DualForm3]
-  @test deca_3d[deca_3d[7:10, :tgt], :type] == [:DualForm3, :DualForm2, :DualForm1, :DualForm0]
-  @test deca_3d[deca_3d[11:14, :tgt], :type] == [:Form3, :Form2, :Form1, :Form0]
-  @test deca_3d[deca_3d[15:16, :tgt], :type] == [:Form3, :DualForm3]
-  @test deca_3d[deca_3d[1:6, :res], :type] == [:Form3, :Form3, :DualForm3, :DualForm2, :Form3, :Form3]
-
   @test type_check(deca_3d, dim=3)
 
   resolve_overloads!(deca_3d, dim=3)
 
-  @test deca_3d[1:4, :op1] == [:d₂, :dual_d₂, :δ₃, :Δ₃]
-  @test deca_3d[5:6, :op1] == [:-, :-]
-  @test deca_3d[7:10, :op1] == [:⋆₀, :⋆₁, :⋆₂, :⋆₃]
-  @test deca_3d[11:14, :op1] == [:⋆₃⁻¹, :⋆₂⁻¹, :⋆₁⁻¹, :⋆₀⁻¹]
-  @test deca_3d[15:16, :op1] == [:∂ₜ, :∂ₜ]
-  @test deca_3d[1:6, :op2] == [:∧₂₁, :∧₁₂, :L₃, :i₃, :∧₃₀, :∧₀₃]
+  # Compare pprint of Term(deca_3d) against the expected repr copied from the
+  # test environment.  This avoids fragile ACSet row-position indexing and
+  # fully documents the inferred types and resolved operators in one place.
+  expected_pprint = "Context:\n  P0::Form0 over I\n  P1::Form1 over I\n  P2::Form2 over I\n  P3::Form3 over I\n  D0::DualForm0 over I\n  D1::DualForm1 over I\n  D2::DualForm2 over I\n  D3::DualForm3 over I\n  R1::Form3 over I\n  R12::Form2 over I\n  R2::DualForm3 over I\n  R20::DualForm2 over I\n  R3::Form2 over I\n  R13::Form1 over I\n  R4::Form3 over I\n  R18::Form3 over I\n  R5::Form3 over I\n  R14::Form0 over I\n  R6::DualForm3 over I\n  R22::Form3 over I\n  R7::DualForm3 over I\n  R15::Form3 over I\n  R8::DualForm2 over I\n  R19::DualForm3 over I\n  R9::DualForm1 over I\n  R16::DualForm3 over I\n  R10::DualForm0 over I\n  R21::Form3 over I\n  R11::Form3 over I\n  R17::Form3 over I\nEquations:\nR1   = d₂(P2)\nR2   = dual_d₂(D2)\nR3   = δ₃(P3)\nR4   = Δ₃(P3)\nR5   = -(P3)\nR6   = -(D3)\nR7   = ⋆₀(P0)\nR8   = ⋆₁(P1)\nR9   = ⋆₂(P2)\nR10   = ⋆₃(P3)\nR11   = ⋆₃⁻¹(D0)\nR12   = ⋆₂⁻¹(D1)\nR13   = ⋆₁⁻¹(D2)\nR14   = ⋆₀⁻¹(D3)\nR15   = ∂ₜ(P3)\nR16   = ∂ₜ(D3)\nR17   = ∧₂₁(P2, P1)\nR18   = ∧₁₂(P1, P2)\nR19   = L₃(P1, D3)\nR20   = i₃(P1, D3)\nR21   = ∧₃₀(P3, P0)\nR22   = ∧₀₃(P0, P3)\n"
+  @test sprint((io, x) -> DiagrammaticEquations.pprint(io, x), Term(deca_3d)) == expected_pprint
 end
 
 @testset "Compilation Transformation" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1281,10 +1281,11 @@ end
 
   resolve_overloads!(deca_3d, dim=3)
 
-  # Compare pprint of Term(deca_3d) against the expected repr copied from the
-  # test environment.  This avoids fragile ACSet row-position indexing and
-  # fully documents the inferred types and resolved operators in one place.
-  expected_pprint = """Context:
+  # Compare pprint of Term(deca_3d) as a set of lines against the expected set
+  # copied from the test environment.  Using set equality avoids brittleness due
+  # to internal ACSet row ordering while still verifying all inferred types and
+  # resolved operators.
+  expected_lines = Set(split("""Context:
   P0::Form0 over I
   P1::Form1 over I
   P2::Form2 over I
@@ -1338,8 +1339,9 @@ R19   = L₃(P1, D3)
 R20   = i₃(P1, D3)
 R21   = ∧₃₀(P3, P0)
 R22   = ∧₀₃(P0, P3)
-"""
-  @test sprint((io, x) -> DiagrammaticEquations.pprint(io, x), Term(deca_3d)) == expected_pprint
+""", "\n"))
+  actual_lines = Set(split(sprint((io, x) -> DiagrammaticEquations.pprint(io, x), Term(deca_3d)), "\n"))
+  @test actual_lines == expected_lines
 end
 
 @testset "Compilation Transformation" begin

--- a/test/language.jl
+++ b/test/language.jl
@@ -1284,7 +1284,61 @@ end
   # Compare pprint of Term(deca_3d) against the expected repr copied from the
   # test environment.  This avoids fragile ACSet row-position indexing and
   # fully documents the inferred types and resolved operators in one place.
-  expected_pprint = "Context:\n  P0::Form0 over I\n  P1::Form1 over I\n  P2::Form2 over I\n  P3::Form3 over I\n  D0::DualForm0 over I\n  D1::DualForm1 over I\n  D2::DualForm2 over I\n  D3::DualForm3 over I\n  R1::Form3 over I\n  R12::Form2 over I\n  R2::DualForm3 over I\n  R20::DualForm2 over I\n  R3::Form2 over I\n  R13::Form1 over I\n  R4::Form3 over I\n  R18::Form3 over I\n  R5::Form3 over I\n  R14::Form0 over I\n  R6::DualForm3 over I\n  R22::Form3 over I\n  R7::DualForm3 over I\n  R15::Form3 over I\n  R8::DualForm2 over I\n  R19::DualForm3 over I\n  R9::DualForm1 over I\n  R16::DualForm3 over I\n  R10::DualForm0 over I\n  R21::Form3 over I\n  R11::Form3 over I\n  R17::Form3 over I\nEquations:\nR1   = d₂(P2)\nR2   = dual_d₂(D2)\nR3   = δ₃(P3)\nR4   = Δ₃(P3)\nR5   = -(P3)\nR6   = -(D3)\nR7   = ⋆₀(P0)\nR8   = ⋆₁(P1)\nR9   = ⋆₂(P2)\nR10   = ⋆₃(P3)\nR11   = ⋆₃⁻¹(D0)\nR12   = ⋆₂⁻¹(D1)\nR13   = ⋆₁⁻¹(D2)\nR14   = ⋆₀⁻¹(D3)\nR15   = ∂ₜ(P3)\nR16   = ∂ₜ(D3)\nR17   = ∧₂₁(P2, P1)\nR18   = ∧₁₂(P1, P2)\nR19   = L₃(P1, D3)\nR20   = i₃(P1, D3)\nR21   = ∧₃₀(P3, P0)\nR22   = ∧₀₃(P0, P3)\n"
+  expected_pprint = """Context:
+  P0::Form0 over I
+  P1::Form1 over I
+  P2::Form2 over I
+  P3::Form3 over I
+  D0::DualForm0 over I
+  D1::DualForm1 over I
+  D2::DualForm2 over I
+  D3::DualForm3 over I
+  R1::Form3 over I
+  R12::Form2 over I
+  R2::DualForm3 over I
+  R20::DualForm2 over I
+  R3::Form2 over I
+  R13::Form1 over I
+  R4::Form3 over I
+  R18::Form3 over I
+  R5::Form3 over I
+  R14::Form0 over I
+  R6::DualForm3 over I
+  R22::Form3 over I
+  R7::DualForm3 over I
+  R15::Form3 over I
+  R8::DualForm2 over I
+  R19::DualForm3 over I
+  R9::DualForm1 over I
+  R16::DualForm3 over I
+  R10::DualForm0 over I
+  R21::Form3 over I
+  R11::Form3 over I
+  R17::Form3 over I
+Equations:
+R1   = d₂(P2)
+R2   = dual_d₂(D2)
+R3   = δ₃(P3)
+R4   = Δ₃(P3)
+R5   = -(P3)
+R6   = -(D3)
+R7   = ⋆₀(P0)
+R8   = ⋆₁(P1)
+R9   = ⋆₂(P2)
+R10   = ⋆₃(P3)
+R11   = ⋆₃⁻¹(D0)
+R12   = ⋆₂⁻¹(D1)
+R13   = ⋆₁⁻¹(D2)
+R14   = ⋆₀⁻¹(D3)
+R15   = ∂ₜ(P3)
+R16   = ∂ₜ(D3)
+R17   = ∧₂₁(P2, P1)
+R18   = ∧₁₂(P1, P2)
+R19   = L₃(P1, D3)
+R20   = i₃(P1, D3)
+R21   = ∧₃₀(P3, P0)
+R22   = ∧₀₃(P0, P3)
+"""
   @test sprint((io, x) -> DiagrammaticEquations.pprint(io, x), Term(deca_3d)) == expected_pprint
 end
 


### PR DESCRIPTION
This PR is meant to lift features that work in 1D and 2D to also work in 3D. This includes automatic typing and operator overloading as well as operator replacement. It also adds new `:Form3` and `:DualForm3` types to allow these changes. Additional additions may be needed in the future to allow for full support.