### PR TITLE
Allow interpolation in Decapodes

### DIFF
--- a/src/language.jl
+++ b/src/language.jl
@@ -222,7 +222,7 @@ end
 Construct a SummationDecapode using the Decapode Domain-Specific Language.
 """
 macro decapode(e)
-  :(SummationDecapode(parse_decapode($(Meta.quot(e)))))
+  :(SummationDecapode(parse_decapode($(Meta.quot(e))))) |> esc
 end
 
 # Verify that @decapode is usable at module-level in source (not just in tests/REPL).

--- a/test/language.jl
+++ b/test/language.jl
@@ -326,6 +326,25 @@ end
   @test nparts(advdiffdp, :Summand) == 2
 end
 
+@testset "Variable Interpolation" begin
+  oscillator = @decapode begin
+   (X,V)::Form0
+   k::Constant
+   ∂ₜ(X) == V
+   ∂ₜ(V) == 5.0 * X
+  end
+  
+  k = 5.0
+  oscillator_interpolated = @decapode begin
+   (X,V)::Form0
+   k::Constant
+   ∂ₜ(X) == V
+   ∂ₜ(V) == $k * X
+  end
+  
+  @test oscillator == oscillator_interpolated
+end
+
 @testset "State Variable Inference" begin
   oscillator = @decapode begin
    (X,V)::Form0


### PR DESCRIPTION
Close #76 

This PR undoes some macro "hygiene" by calling `esc` on the entire output. The prior behavior (without `esc`) is that interpolated values were attempted to be evaluated in the `DiagrammaticEquations` module itself.