### PR TITLE
Update rewriting rules for 1D DEC

### DIFF
--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -200,26 +200,7 @@ end
 # Default Rewrite Rules
 # ---------------------
 
-rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
-  Op1SDRule(
-    :Δ₀,
-    @decapode begin
-      y == ∘(d,δ)(X)
-    end),
-
-  Op1SDRule(
-    :Δ₁,
-    @decapode begin
-      (X,y)::Form1
-      y == ∘(d,δ)(X) + ∘(δ,d)(X)
-    end),
-
-  Op1SDRule(
-    :Δ₂,
-    @decapode begin
-      y == ∘(δ,d)(X)
-    end),
-
+rewrite_rules_nD = Vector{AbstractSDRewriteRule}([
   Op1SDRule(
     :δ,
     @decapode begin
@@ -236,6 +217,56 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
     :δ₂,
     @decapode begin
       y == ∘(⋆,d,⋆)(X)
+    end),
+
+  Op1SDRule(
+    :Δ₀,
+    @decapode begin
+      y == ∘(d,δ)(X)
+    end)])
+
+rewrite_rules_1D = Vector{AbstractSDRewriteRule}([
+  rewrite_rules_nD...,
+
+  Op1SDRule(
+    :Δ₁,
+    @decapode begin
+      (X,y)::Form1
+      y == ∘(δ,d)(X)
+    end),
+
+  Op2SDRule(
+    :ι₁,
+    @decapode begin
+      y == -1*⋆((⋆p1) ∧ p2)
+    end),
+
+  Op2SDRule(
+    :L₀,
+    @decapode begin
+      y == ι(p1, d(p2))
+    end),
+
+  Op2SDRule(
+    :L₁,
+    @decapode begin
+      y == d(ι(p1, p2))
+    end)])
+
+rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
+  rewrite_rules_nD...,
+
+  Op1SDRule(
+    :Δ₁,
+    @decapode begin
+      (X,y)::Form1
+      y == ∘(d,δ)(X) + ∘(δ,d)(X)
+    end),
+
+  Op1SDRule(
+    :Δ₂,
+    @decapode begin
+      y == ∘(δ,d)(X)
     end),
 
   Op2SDRule(
@@ -262,5 +293,14 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
       y == d(ι(p1, p2))
     end)])
 
-rewrite!(d::SummationDecapode) =
-  (infer_resolve!(d); rewrite!(d, rewrite_rules_2D))
+function rewrite!(d::SummationDecapode; dimension::Int = 2)
+  infer_resolve!(d)
+  if d == 1
+    rewrite!(d, rewrite_rules_1D)
+  elseif d == 2
+    rewrite!(d, rewrite_rules_2D)
+  else
+    d
+  end
+end
+

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -1,4 +1,5 @@
 using ..DiagrammaticEquations
+using MLStyle
 
 # TODO: You could write a method which auto-generates these rules given degree N.
 """
@@ -210,19 +211,33 @@ rewrite_rules_nD = Vector{AbstractSDRewriteRule}([
   Op1SDRule(
     :δ₁,
     @decapode begin
+      X::Form1
+      y::Form0
       y == ∘(⋆,d,⋆)(X)
     end),
 
   Op1SDRule(
     :δ₂,
     @decapode begin
+      X::Form2
+      y::Form1
       y == ∘(⋆,d,⋆)(X)
     end),
 
   Op1SDRule(
     :Δ₀,
     @decapode begin
+      (X, y)::Form0
       y == ∘(d,δ)(X)
+    end),
+
+  Op2SDRule(
+    :i₁,
+    @decapode begin
+      p1::Form1
+      p2::DualForm1
+      y::DualForm0
+      y == -1*⋆((⋆p1) ∧ p2)
     end)])
 
 rewrite_rules_1D = Vector{AbstractSDRewriteRule}([
@@ -236,21 +251,15 @@ rewrite_rules_1D = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
-    :ι₁,
-    @decapode begin
-      y == -1*⋆((⋆p1) ∧ p2)
-    end),
-
-  Op2SDRule(
     :L₀,
     @decapode begin
-      y == ι(p1, d(p2))
+      y == i(p1, d(p2))
     end),
 
   Op2SDRule(
     :L₁,
     @decapode begin
-      y == d(ι(p1, p2))
+      y == d(i(p1, p2))
     end)])
 
 rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
@@ -270,37 +279,29 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
-    :ι₁,
-    @decapode begin
-      y == -1*⋆((⋆p1) ∧ p2)
-    end),
-
-  Op2SDRule(
     :L₀,
     @decapode begin
-      y == ι(p1, d(p2))
+      y == i(p1, d(p2))
     end),
 
   Op2SDRule(
     :L₁,
     @decapode begin
-      y == ι(p1, d(p2)) + d(ι(p1, p2))
+      y == i(p1, d(p2)) + d(i(p1, p2))
     end),
 
   Op2SDRule(
     :L₂,
     @decapode begin
-      y == d(ι(p1, p2))
+      y == d(i(p1, p2))
     end)])
 
 function rewrite!(d::SummationDecapode; dimension::Int = 2)
-  infer_resolve!(d)
-  if d == 1
-    rewrite!(d, rewrite_rules_1D)
-  elseif d == 2
-    rewrite!(d, rewrite_rules_2D)
-  else
-    d
+  infer_resolve!(d, dim = dimension)
+  @match dimension begin
+    1 => rewrite!(d, rewrite_rules_1D)
+    2 => rewrite!(d, rewrite_rules_2D)
+    _ => d
   end
 end
 

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -232,13 +232,11 @@ rewrite_rules_nD = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
-    :i₁,
+    :L₀,
     @decapode begin
-      p1::Form1
-      p2::DualForm1
-      y::DualForm0
-      y == -1*⋆((⋆p1) ∧ p2)
-    end)])
+      y == i(p1, d(p2))
+    end),
+  ])
 
 rewrite_rules_1D = Vector{AbstractSDRewriteRule}([
   rewrite_rules_nD...,
@@ -251,9 +249,9 @@ rewrite_rules_1D = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
-    :L₀,
+    :i₁,
     @decapode begin
-      y == i(p1, d(p2))
+      y == ⋆((⋆p2) ∧ p1)
     end),
 
   Op2SDRule(
@@ -279,9 +277,9 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
-    :L₀,
+    :i₁,
     @decapode begin
-      y == i(p1, d(p2))
+      y == -1 * ⋆((⋆p1) ∧ p2)
     end),
 
   Op2SDRule(

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -279,7 +279,7 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
   Op2SDRule(
     :i₁,
     @decapode begin
-      y == -1 * ⋆((⋆p1) ∧ p2)
+      y == -1 * ⋆((⋆p2) ∧ p1)
     end),
 
   Op2SDRule(

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -297,8 +297,8 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
 function rewrite!(d::SummationDecapode; dimension::Int = 2)
   infer_resolve!(d, dim = dimension)
   @match dimension begin
-    1 => rewrite!(d, rewrite_rules_1D)
-    2 => rewrite!(d, rewrite_rules_2D)
+    1 => rewrite!(d, rewrite_rules_1D, dimension)
+    2 => rewrite!(d, rewrite_rules_2D, dimension)
     _ => d
   end
 end

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -283,6 +283,12 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
     end),
 
   Op2SDRule(
+    :i₂,
+    @decapode begin
+      y == ⋆((⋆p2) ∧ p1)
+    end),
+
+  Op2SDRule(
     :L₁,
     @decapode begin
       y == i(p1, d(p2)) + d(i(p1, p2))

--- a/src/deca/deca_acset.jl
+++ b/src/deca/deca_acset.jl
@@ -301,7 +301,7 @@ rewrite_rules_2D = Vector{AbstractSDRewriteRule}([
     end)])
 
 function rewrite!(d::SummationDecapode; dimension::Int = 2)
-  infer_resolve!(d, dim = dimension)
+  infer_types!(d, default_operators(dimension))
   @match dimension begin
     1 => rewrite!(d, rewrite_rules_1D, dimension)
     2 => rewrite!(d, rewrite_rules_2D, dimension)

--- a/src/openoperators.jl
+++ b/src/openoperators.jl
@@ -313,10 +313,11 @@ end
 replace_all_op2s!(d::SummationDecapode, r::Op2SDRule) =
   replace_all_op2s!(d, r.LHS, r.RHS, r.proj1, r.proj2)
 
-function rewrite!(d::SummationDecapode, rules::AbstractVector{AbstractSDRewriteRule})
+function rewrite!(d::SummationDecapode, rules::AbstractVector{AbstractSDRewriteRule}, dimension)
   any_applied = true
   while any_applied
     expand_operators!(d)
+    infer_resolve!(d, dim = dimension)
     any_applied = false
     for r in rules
       any_applied = apply_rule!(d, r) || any_applied

--- a/test/openoperators.jl
+++ b/test/openoperators.jl
@@ -332,6 +332,6 @@ end
     ∂ₜ(V) == V̇
   end
   rewrite!(Brusselator)
-  @test sort(Brusselator[:op1], by=string) == sort([:d,:⋆,:d,:⋆,:d,:⋆,:d,:⋆,:∂ₜ,:∂ₜ], by=string)
+  @test sort(Brusselator[:op1], by=string) == sort([:dual_d₁, :dual_d₁, :d₀, :d₀, :∂ₜ, :∂ₜ, :⋆₀⁻¹, :⋆₀⁻¹, :⋆₁, :⋆₁], by=string)
 end
 


### PR DESCRIPTION
PR #75 implemented a declarative term rewriting system for diagrammatic equations.

This PR adds rules for the 1D Discrete Exterior Calculus, and implements changes where necessary to ensure downstream compatibility with [PR 370](https://github.com/AlgebraicJulia/Decapodes.jl/pull/370) of Decapodes.